### PR TITLE
feat: Persist application state on page refresh

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -36,6 +36,8 @@ bun tauri dev
 
 This will start the Vite development server for the frontend and build and run the Tauri application.
 
+**Note:** The user is running the application on the side, so there is no need to run it manually.
+
 ### Building
 
 To build the application for production, use the following command:

--- a/TODOS.md
+++ b/TODOS.md
@@ -61,7 +61,7 @@ This file outlines the recommended to-do items for the Tauri File Explorer proje
 
 ## Known Issues
 
-*   [ ] **State Persistence on Refresh**: The application state is not saved and restored on page refresh. When the user presses F5, the application resets to a blank screen. The current directory path should be persisted, either in the URL or in `localStorage`, to restore the state properly.
+*   [x] **State Persistence on Refresh**: The application state is not saved and restored on page refresh. When the user presses F5, the application resets to a blank screen. The current directory path should be persisted, either in the URL or in `localStorage`, to restore the state properly.
 *   [ ] **URL Doesn't Reflect Current Directory**: The URL does not update to reflect the current directory path. This prevents bookmarking and direct navigation to specific directories. The router should be updated to include the current path (e.g., `/files/C:/Users/`).
 *   [ ] **Missing Error Handling**: There is no error handling for the `invoke` calls to the backend. If an error occurs when reading a directory (e.g., permission denied), the application does not display a user-friendly error message.
 *   [ ] **State Inconsistency**: The `currentDirectory` in the Pinia store is not updated when the `getDirectory` function is called. This can lead to a mismatch between the displayed directory content and the actual current directory path in the state.

--- a/src/App.vue
+++ b/src/App.vue
@@ -2,18 +2,17 @@
 // This starter template is using Vue 3 <script setup> SFCs
 // Check out https://vuejs.org/api/sfc-script-setup.html#script-setup
 import Header from "./components/Header.vue";
-import {useDirectoryStore} from "./stores/store";
+import { useDirectoryStore } from "./stores/store";
 
 const directoryStore = useDirectoryStore();
 </script>
 
 <template>
-  <Header />
-  <p>{{directoryStore.currentDirectory}}</p>
-  <main>
-    <RouterView />
-  </main>
+    <Header />
+    <p>{{ directoryStore.currentDirectory }}</p>
+    <main>
+        <RouterView />
+    </main>
 </template>
 
-<style scoped>
-</style>
+<style scoped></style>

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -1,5 +1,5 @@
 import {defineStore} from 'pinia'
-import {ref} from "vue";
+import {ref, watch} from "vue";
 
 import {invoke} from "@tauri-apps/api/core";
 
@@ -11,12 +11,21 @@ export type DirectoryItem = {
     size: number;
 }
 export const useDirectoryStore = defineStore('directory', () => {
-  const currentDirectory = ref("");
-  const currentDirectoryItems = ref<DirectoryItem[]>([]);
+  const currentDirectory = ref(localStorage.getItem("currentDirectory") || "");
+  const currentDirectoryItems = ref<DirectoryItem[]>(JSON.parse(localStorage.getItem("currentDirectoryItems") || "[]"));
+
+    watch(currentDirectory, (newPath) => {
+        localStorage.setItem("currentDirectory", newPath);
+    });
+
+    watch(currentDirectoryItems, (newItems) => {
+        localStorage.setItem("currentDirectoryItems", JSON.stringify(newItems));
+    });
 
   async function getDirectory(path: string) {
       console.log("getDirectory", path);
       currentDirectoryItems.value = await invoke<DirectoryItem[]>("get_directory", {path: path || currentDirectory.value});
+      currentDirectory.value = path;
   }
   return {
       currentDirectory,


### PR DESCRIPTION
This commit adds state persistence functionality to the application. The
current directory path and the directory items are now saved to 
`localStorage` and restored on page refresh. This ensures that the 
user's navigation state is preserved, even when they refresh the page.

The key changes are:

- The `currentDirectory` and `currentDirectoryItems` in the Pinia store are initialized from `localStorage` if available.
- Watchers are added to update `localStorage` whenever the `currentDirectory` or `currentDirectoryItems` change.
- The `getDirectory` function now updates the `currentDirectory` value in the store.

These changes improve the user experience by preventing the application from resetting to a blank state on page refresh.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Directory selection and contents now persist across page refreshes for a smoother experience.

- Documentation
  - Clarified development workflow: manual app startup is unnecessary when running the development command.
  - Updated Known Issues: marked state persistence as completed; added items for improving backend error handling and error propagation to the frontend.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->