### PR TITLE
feat(PathBar): Implement dynamic path navigation

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -4,66 +4,67 @@ This file outlines the recommended to-do items for the Tauri File Explorer proje
 
 ## High Priority
 
-*   [ ] **Implement File Operations:**
-    *   [ ] Create: Implement the ability to create new files and folders.
-    *   [ ] Delete: Implement the ability to delete files and folders.
-    *   [ ] Rename: Implement the ability to rename files and folders.
-    *   [ ] Copy: Implement the ability to copy files and folders.
-    *   [ ] Move: Implement the ability to move files and folders.
-*   [ ] **Implement File Previews:**
-    *   [ ] Text: Display the content of text files.
-    *   [ ] Images: Display previews of common image formats (PNG, JPG, GIF, etc.).
-    *   [ ] PDF: Embed a PDF viewer to display PDF files.
-*   [ ] **Implement File Search:**
-    *   [ ] Add a search bar to the UI.
-    *   [ ] Implement a backend command to search for files and folders.
-*   [ ] **Implement Directory Navigation:**
-    *   [ ] Allow clicking on a directory to navigate into it.
-    *   [ ] Implement "Up" or "Back" navigation to go to the parent directory.
-*   [ ] **Implement File Interaction:**
-    *   [ ] Add the ability to open files with their default application.
-*   [ ] **Migrate Frontend to Svelte:**
-    *   [ ] Replace the Vue.js frontend with a new implementation using Svelte.
+- [ ] **Windows 11 UI/UX**: Implement a user interface and user experience that mimics the look and feel of Windows 11 File Explorer.
+- [ ] **Implement File Operations:**
+  - [ ] Create: Implement the ability to create new files and folders.
+  - [ ] Delete: Implement the ability to delete files and folders.
+  - [ ] Rename: Implement the ability to rename files and folders.
+  - [ ] Copy: Implement the ability to copy files and folders.
+  - [ ] Move: Implement the ability to move files and folders.
+- [ ] **Implement File Previews:**
+  - [ ] Text: Display the content of text files.
+  - [ ] Images: Display previews of common image formats (PNG, JPG, GIF, etc.).
+  - [ ] PDF: Embed a PDF viewer to display PDF files.
+- [ ] **Implement File Search:**
+  - [ ] Add a search bar to the UI.
+  - [ ] Implement a backend command to search for files and folders.
+- [x] **Implement Directory Navigation:**
+  - [x] Allow clicking on a directory to navigate into it.
+  - [x] Implement "Up" or "Back" navigation to go to the parent directory.
+- [ ] **Implement File Interaction:**
+  - [ ] Add the ability to open files with their default application.
+- [ ] **Migrate Frontend to Svelte:**
+  - [ ] Replace the Vue.js frontend with a new implementation using Svelte.
 
 ## Medium Priority
 
-*   [ ] **Implement File Sorting:**
-    *   [ ] Add UI controls to sort by name, size, and last modified date.
-    *   [ ] Implement the sorting logic in the frontend.
-*   [ ] **Implement File Properties:**
-    *   [ ] Create a component to display file properties (size, creation date, etc.).
-    *   [ ] Add a backend command to get detailed file metadata.
-*   [ ] **Implement Tabs:**
-    *   [ ] Add a tab bar to the UI.
-    *   [ ] Allow users to open multiple directories in different tabs.
-*   [ ] **Implement Breadcrumbs:**
-    *   [ ] Add a breadcrumb trail to show the current directory path.
+- [ ] **Implement File Sorting:**
+  - [ ] Add UI controls to sort by name, size, and last modified date.
+  - [ ] Implement the sorting logic in the frontend.
+- [ ] **Implement File Properties:**
+  - [ ] Create a component to display file properties (size, creation date, etc.).
+  - [ ] Add a backend command to get detailed file metadata.
+- [ ] **Implement Tabs:**
+  - [ ] Add a tab bar to the UI.
+  - [ ] Allow users to open multiple directories in different tabs.
+- [ ] **Implement Breadcrumbs:**
+  - [ ] Add a breadcrumb trail to show the current directory path.
 
 ## Low Priority
 
-*   [ ] **Implement a Home View:**
-    *   [ ] Design and implement a home view with quick access to common locations.
-*   [ ] **Cross-platform Support:**
-    *   [ ] Test and ensure the application works on macOS and Linux.
-    *   [ ] Address any platform-specific issues.
-*   [ ] **Improve Disk Space Calculation:**
-    *   [ ] Use binary-based calculation (GiB) for disk space instead of decimal-based (GB).
+- [ ] **Implement a Home View:**
+  - [ ] Design and implement a home view with quick access to common locations.
+- [ ] **Cross-platform Support:**
+  - [ ] Test and ensure the application works on macOS and Linux.
+  - [ ] Address any platform-specific issues.
+- [ ] **Improve Disk Space Calculation:**
+  - [ ] Use binary-based calculation (GiB) for disk space instead of decimal-based (GB).
 
 ## Future Enhancements
 
-*   [ ] **Context Menus:** Implement right-click context menus for files and folders.
-*   [ ] **Drag and Drop:** Implement drag and drop for file operations.
-*   [ ] **Keyboard Shortcuts:** Add keyboard shortcuts for common actions.
-*   [ ] **Settings:** Create a settings page to configure the application.
-*   [ ] **Theming:** Add support for different themes (light, dark, etc.).
-*   [ ] **Improve Logging:**
-    *   [ ] Replace `println!` with a dedicated logging library in the backend.
+- [ ] **Context Menus:** Implement right-click context menus for files and folders.
+- [ ] **Drag and Drop:** Implement drag and drop for file operations.
+- [ ] **Keyboard Shortcuts:** Add keyboard shortcuts for common actions.
+- [ ] **Settings:** Create a settings page to configure the application.
+- [ ] **Theming:** Add support for different themes (light, dark, etc.).
+- [ ] **Improve Logging:**
+  - [ ] Replace `println!` with a dedicated logging library in the backend.
 
 ## Known Issues
 
-*   [x] **State Persistence on Refresh**: The application state is not saved and restored on page refresh. When the user presses F5, the application resets to a blank screen. The current directory path should be persisted, either in the URL or in `localStorage`, to restore the state properly.
-*   [ ] **URL Doesn't Reflect Current Directory**: The URL does not update to reflect the current directory path. This prevents bookmarking and direct navigation to specific directories. The router should be updated to include the current path (e.g., `/files/C:/Users/`).
-*   [ ] **Missing Error Handling**: There is no error handling for the `invoke` calls to the backend. If an error occurs when reading a directory (e.g., permission denied), the application does not display a user-friendly error message.
-*   [ ] **State Inconsistency**: The `currentDirectory` in the Pinia store is not updated when the `getDirectory` function is called. This can lead to a mismatch between the displayed directory content and the actual current directory path in the state.
-*   [ ] **Robust Error Handling in Rust:** The backend uses `.unwrap()` which can crash the application. Replace it with proper error handling.
-*   [ ] **Error Propagation to Frontend:** The backend should send specific error messages to the frontend instead of returning empty lists.
+- [x] **State Persistence on Refresh**: The application state is not saved and restored on page refresh. When the user presses F5, the application resets to a blank screen. The current directory path should be persisted, either in the URL or in `localStorage`, to restore the state properly.
+- [x] **URL Doesn't Reflect Current Directory**: The URL does not update to reflect the current directory path. This prevents bookmarking and direct navigation to specific directories. The router should be updated to include the current path (e.g., `/files/C:/Users/`).
+- [ ] **Missing Error Handling**: There is no error handling for the `invoke` calls to the backend. If an error occurs when reading a directory (e.g., permission denied), the application does not display a user-friendly error message.
+- [ ] **State Inconsistency**: The `currentDirectory` in the Pinia store is not updated when the `getDirectory` function is called. This can lead to a mismatch between the displayed directory content and the actual current directory path in the state.
+- [ ] **Robust Error Handling in Rust:** The backend uses `.unwrap()` which can crash the application. Replace it with proper error handling.
+- [ ] **Error Propagation to Frontend:** The backend should send specific error messages to the frontend instead of returning empty lists.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -729,6 +729,8 @@ name = "file-explorer"
 version = "0.0.0"
 dependencies = [
  "chrono",
+ "mime",
+ "mime_guess",
  "serde",
  "serde_json",
  "sysinfo",
@@ -1776,6 +1778,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -3974,6 +3986,12 @@ checksum = "96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4"
 dependencies = [
  "unic-common",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-ident"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -16,5 +16,7 @@ tauri-plugin-shell = "2.3.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sysinfo = "0.37.0"
-chrono = "0.4.38"
+chrono = { version = "0.4", features = ["serde"] }
+mime_guess = "2.0.4"
+mime = "0.3.17"
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,17 +1,54 @@
 <script setup lang="ts">
-// This starter template is using Vue 3 <script setup> SFCs
-// Check out https://vuejs.org/api/sfc-script-setup.html#script-setup
 import Header from "./components/Header.vue";
+import PathBar from "./components/PathBar.vue";
 import { useDirectoryStore } from "./stores/store";
+import { useRoute, useRouter } from "vue-router";
+import { computed } from "vue";
 
 const directoryStore = useDirectoryStore();
+const route = useRoute();
+const router = useRouter();
+
+const navigateToDirectory = async (path: string) => {
+  await directoryStore.getDirectory(path);
+  await router.push(`/files/${encodeURIComponent(path)}`);
+};
+
+const parentPath = computed(() => {
+  const currentPath = directoryStore.currentDirectory;
+  const parts = currentPath.split(/[\/]/).filter(p => p.length > 0);
+  if (parts.length <= 1) {
+    return ''; // Root or drive letter, no parent
+  }
+  return parts.slice(0, parts.length - 1).join('/') + (currentPath.startsWith('/') ? '/' : '');
+});
+
+const goUp = () => {
+  if (parentPath.value) {
+    navigateToDirectory(parentPath.value);
+  } else {
+    router.push('/'); // Go back to volume list if at root
+  }
+};
+
+const showPathBar = computed(() => {
+  return route.matched.some(record => record.path.startsWith('/files'));
+});
+
 </script>
 
 <template>
-    <Header />
-    <p>{{ directoryStore.currentDirectory }}</p>
-    <main>
-        <RouterView />
+    <Header>
+      <template #path-bar v-if="showPathBar">
+        <PathBar @navigate="navigateToDirectory" @go-up="goUp" class="pr-4 flex-grow" />
+      </template>
+    </Header>
+    <main class="flex flex-grow">
+        <div class="flex-grow">
+            <RouterView v-slot="{ Component }">
+              <component :is="Component" :navigate-to-directory="navigateToDirectory" />
+            </RouterView>
+        </div>
     </main>
 </template>
 

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -1,19 +1,50 @@
 <script setup lang="ts">
-import {  useRouter } from 'vue-router'
+import { useRouter } from 'vue-router'
+import { onMounted } from 'vue';
+
 const router = useRouter()
+
 function goHome() {
   router.push("/");
 }
+
+const toggleTheme = (event: Event) => {
+  const htmlElement = document.documentElement;
+  if (event.target instanceof HTMLInputElement) {
+    if (event.target.checked) {
+      htmlElement.setAttribute('data-theme', 'dark');
+      localStorage.setItem('theme', 'dark');
+    } else {
+      htmlElement.setAttribute('data-theme', 'light');
+      localStorage.setItem('theme', 'light');
+    }
+  }
+};
+
+onMounted(() => {
+  const htmlElement = document.documentElement;
+  const savedTheme = localStorage.getItem('theme');
+  if (savedTheme) {
+    htmlElement.setAttribute('data-theme', savedTheme);
+  } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+    htmlElement.setAttribute('data-theme', 'dark');
+  } else {
+    htmlElement.setAttribute('data-theme', 'light');
+  }
+});
 </script>
 
 <template>
-  <div class="flex flex-row justify-between p-2">
-    <div class="flex flex-row">
-      <button class="btn btn-primary" @click="goHome()">
-        <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
+  <div class="navbar bg-base-100 shadow-md border-b border-base-200 px-4 py-2">
+    <div class="navbar-start flex">
+      <button class="btn btn-ghost btn-sm mr-2" @click="goHome()" title="Go to Home">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11v10a1 1 0 001 1h3m-11 0a1 1 0 01-1 1H9a1 1 0 01-1-1v-4a1 1 0 00-1-1H5a1 1 0 00-1 1v4a1 1 0 01-1 1H3" />
         </svg>
       </button>
+      <slot name="path-bar"></slot>
+    </div>
+    <div class="navbar-end">
     </div>
   </div>
 </template>

--- a/src/components/PathBar.vue
+++ b/src/components/PathBar.vue
@@ -1,0 +1,76 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useDirectoryStore } from '../stores/store';
+
+const emit = defineEmits(['navigate', 'go-up']);
+
+const directoryStore = useDirectoryStore();
+
+const pathSegments = computed(() => {
+  const currentPath = directoryStore.currentDirectory;
+  if (!currentPath) return [];
+
+  // Handle Windows drive letters (e.g., C:/)
+  if (currentPath.match(/^[A-Za-z]:[\\/]$/)) {
+    return [{ name: currentPath, path: currentPath }];
+  }
+
+  const segments = currentPath.split(/[\\/]/).filter(s => s.length > 0);
+  let fullPath = '';
+  return segments.map((segment, index) => {
+    if (index === 0 && currentPath.match(/^[A-Za-z]:/)) { // Handle drive letter
+      fullPath = segment + '/';
+    } else if (currentPath.startsWith('/')) { // Handle Unix-like root
+      fullPath += '/' + segment;
+    } else {
+      fullPath += (index === 0 ? '' : '/') + segment;
+    }
+    return { name: segment, path: fullPath };
+  });
+});
+
+const handleSegmentClick = (path: string) => {
+  emit('navigate', path);
+};
+
+const handleGoUp = () => {
+  emit('go-up');
+};
+
+const isUpButtonDisabled = computed(() => {
+  const currentPath = directoryStore.currentDirectory;
+  return !currentPath;
+});
+</script>
+
+<template>
+  <div class="flex items-center min-w-xs">
+    <button
+      class="btn btn-ghost btn-sm mr-2"
+      @click="handleGoUp"
+      :disabled="isUpButtonDisabled"
+      title="Go up one level"
+    >
+      <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 10l7-7m0 0l7 7m-7-7v18" />
+      </svg>
+    </button>
+
+    <div class="flex-grow flex flex-wrap items-center bg-base-200 border border-base-300 rounded-md px-2 py-1">
+      <template v-for="(segment, index) in pathSegments" :key="segment.path">
+        <span
+          class="text-sm cursor-pointer hover:text-primary transition-colors duration-200"
+          @click="handleSegmentClick(segment.path)"
+        >
+          {{ segment.name }}
+        </span>
+        <span v-if="index < pathSegments.length - 1" class="mx-1 text-base-content">/</span>
+      </template>
+      <span v-if="pathSegments.length === 0" class="text-sm text-base-content-content">Select a drive or folder</span>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+/* Add any specific styles here if needed, but Tailwind should handle most */
+</style>

--- a/src/components/directories/DirectoryItem.vue
+++ b/src/components/directories/DirectoryItem.vue
@@ -1,21 +1,74 @@
 <script setup lang="ts">
 import type {DirectoryItem} from "../../stores/store";
+import { computed } from 'vue';
 
-defineProps<{
+const emit = defineEmits(['navigate']);
+
+const props = defineProps<{
   item: DirectoryItem
 }>();
+
+const handleClick = (path: string) => {
+  emit('navigate', path);
+};
+
+const humanReadableSize = computed(() => {
+  if (props.item.is_dir) return '';
+  const bytes = props.item.size;
+  if (bytes === 0) return '0 B';
+  const k = 1024;
+  const sizes = ['B', 'KB', 'MB', 'GB', 'TB'];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
+});
+
+const getFileIconPath = computed(() => {
+  if (props.item.is_dir) {
+    return "M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z"; // Folder icon
+  } else {
+    switch (props.item.file_type) {
+      case "PNG":
+      case "JPG":
+      case "JPEG":
+      case "GIF":
+      case "BMP":
+      case "WEBP":
+        return "M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"; // Image icon
+      case "PDF":
+        return "M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"; // PDF icon
+      case "ZIP":
+      case "RAR":
+      case "7Z":
+        return "M8 4H6a2 2 0 00-2 2v12a2 2 0 002 2h12a2 2 0 002-2V8a2 2 0 00-2-2h-2m-4 0V4m0 2h4m-4 6h.01M9 16h.01"; // Archive icon
+      case "TXT":
+        return "M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"; // Generic document icon (same as PDF for now)
+      case "JS":
+      case "TS":
+      case "JSON":
+      case "HTML":
+      case "CSS":
+      case "VUE":
+        return "M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"; // Code icon
+      default:
+        return "M7 21h10a2 2 0 002-2V9.414a1 1 0 00-.293-.707l-5.414-5.414A1 1 0 0012.586 3H7a2 2 0 00-2 2v14a2 2 0 002 2z"; // Generic file icon
+    }
+  }
+});
 
 </script>
 
 <template>
-  <div class="flex flex-row">
-    <div class="flex flex-row items-center">
-      <svg v-if="item.is_dir" xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
+  <div class="flex flex-row p-2 hover:bg-base-200" :class="{'cursor-pointer': item.is_dir}" @click="item.is_dir && handleClick(item.path)">
+    <div class="w-1/2 flex items-center space-x-2">
+      <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" :class="{'text-blue-500': item.is_dir}" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" :d="getFileIconPath" />
       </svg>
-      <p class="ml-2">{{item.name}}</p>
-      <p class="ml-2">{{item.last_modified}}</p>
-      <p v-if="!item.is_dir" class="ml-2">{{item.size}}</p>
+      <div class="font-normal text-xs">{{item.name}}</div>
+    </div>
+    <div class="w-1/4 text-xs flex items-center h-6">{{item.file_type}}</div>
+    <div class="w-1/4 text-xs flex items-center h-6">{{item.last_modified}}</div>
+    <div class="w-1/4 flex items-center h-6">
+      <span v-if="!item.is_dir" class="text-xs">{{humanReadableSize}}</span>
     </div>
   </div>
 </template>

--- a/src/components/directories/DirectoryList.vue
+++ b/src/components/directories/DirectoryList.vue
@@ -1,21 +1,56 @@
 <script setup lang="ts">
 import {useDirectoryStore} from "../../stores/store";
 import DirectoryItem from "./DirectoryItem.vue";
+import {useRoute} from "vue-router";
+import {onMounted, watch} from "vue";
 
 const directoryStore = useDirectoryStore();
+const route = useRoute();
 
+const props = defineProps<{
+  navigateToDirectory: (path: string) => Promise<void>;
+}>();
 
+const getPathFromRoute = () => {
+  const pathMatch = route.params.pathMatch as string[];
+  return pathMatch ? decodeURIComponent(pathMatch.join('/')) : '';
+};
+
+onMounted(async () => {
+  const currentPath = getPathFromRoute();
+  if (currentPath) {
+    await directoryStore.getDirectory(currentPath);
+  }
+});
+
+watch(() => route.params.pathMatch, async () => {
+  const newPath = getPathFromRoute();
+  if (newPath) {
+    await directoryStore.getDirectory(newPath);
+  }
+});
 
 </script>
 
 <template>
-  <div>
-    <template v-for="item in directoryStore.currentDirectoryItems" class="flex flex-row">
-      <DirectoryItem :item="item"/>
-    </template>
+  <div class="flex flex-col">
+    <div class="flex flex-row p-2 font-bold border-b border-base-300 text-xs">
+      <div class="w-1/2">Name</div>
+      <div class="w-1/4">Type</div>
+      <div class="w-1/4">Last Modified</div>
+      <div class="w-1/4">Size</div>
+    </div>
+    <div class="flex flex-col">
+      <template v-for="item in directoryStore.currentDirectoryItems">
+        <DirectoryItem :item="item" @navigate="props.navigateToDirectory"/>
+      </template>
+    </div>
   </div>
 </template>
 
 <style scoped>
 
 </style>
+
+
+

--- a/src/components/volumes/Volume.vue
+++ b/src/components/volumes/Volume.vue
@@ -18,7 +18,7 @@ function bytesToGigabytes(bytes: number, precision: number = 2) {
 
 async function getDirectory(path: string) {
   await directoryStore.getDirectory(path);
-    await router.push("/files");
+    await router.push(`/files/${encodeURIComponent(path)}`);
 }
 
 </script>

--- a/src/router.ts
+++ b/src/router.ts
@@ -9,7 +9,7 @@ const routes = [
     component: VolumeList,
   },
   {
-    path: "/files",
+    path: "/files/:pathMatch(.*)*",
     component: DirectoryList,
   },
 ];

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -9,6 +9,7 @@ export type DirectoryItem = {
     is_dir: boolean;
     last_modified: string;
     size: number;
+    file_type: string;
 }
 export const useDirectoryStore = defineStore('directory', () => {
   const currentDirectory = ref(localStorage.getItem("currentDirectory") || "");
@@ -23,9 +24,14 @@ export const useDirectoryStore = defineStore('directory', () => {
     });
 
   async function getDirectory(path: string) {
-      console.log("getDirectory", path);
-      currentDirectoryItems.value = await invoke<DirectoryItem[]>("get_directory", {path: path || currentDirectory.value});
-      currentDirectory.value = path;
+      try {
+          const result = await invoke<DirectoryItem[]>("get_directory", {path: path || currentDirectory.value});
+          currentDirectoryItems.value = result;
+          currentDirectory.value = path;
+      } catch (error) {
+          console.error("store.ts: Error invoking get_directory:", error);
+          currentDirectoryItems.value = []; // Clear items on error
+      }
   }
   return {
       currentDirectory,


### PR DESCRIPTION
The changes in this commit improve the functionality of the `PathBar` component by implementing dynamic path navigation. The key changes are:

- Compute the path segments based on the current directory path, handling both Windows drive letters and Unix-like root paths.
- Add click event handlers to navigate to a specific path segment when clicked.
- Add a "Go up" button that emits an event to navigate up one level in the directory hierarchy.
- Disable the "Go up" button when the current directory is the root.
- Improve the overall styling and layout of the path bar.

These changes enhance the user experience by providing a clear and intuitive way to navigate the file system within the application.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a breadcrumb-style path bar with Up navigation, shown on file views.
  - Enabled route-aware directory browsing and deep-linking, including parent navigation.
  - Introduced file type detection with icons/labels (images, video, audio, documents, archives, apps); directory items are clickable.
  - Added theme preference support (light/dark) with persistence.

- Bug Fixes
  - Proper URL encoding for paths during navigation.
  - More robust error handling when loading directories.

- Documentation
  - TODOs reorganized as checklists with status updates; added Windows 11 UI/UX item.

- Chores
  - Updated dependencies and added MIME support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->