### PR TITLE
Add file explorer docs and agent rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,40 +1,199 @@
-# Project Agent Rules
+# Agent Guide
 
-These rules capture recurring implementation decisions for `file-explorer`.
+This repository is a Windows-first desktop file explorer built with Tauri 2, SvelteKit, TypeScript, Bun, Rust, and Windows shell integration.
+
+Before making implementation changes, skim the [docs index](docs/README.md). The minimum reading set is:
+
+- `docs/product-vision.md`
+- `docs/architecture-blueprint.md`
+- `docs/development-workflow.md`
+- `docs/handbook/README.md`
+- `docs/decisions/` when touching locked-in boundaries
+
+## Core Constraints
+
+- Keep the filesystem hot path in Rust.
+- Keep Svelte as a thin renderer for state already shaped by Rust.
+- Do not let frontend code own sorting, searching, metadata hydration, or file operations.
+- Do not block the UI on filesystem calls.
+- Do not add non-virtualized large lists.
+- Keep expensive enrichments off navigation first paint: thumbnails, Git state, hashes, previews, cloud metadata, archive inspection, and network providers.
+- Keep Windows native integration in `crates/platform-windows` behind platform boundaries.
+- Preserve restart-safe and cancellation-aware navigation semantics: stale jobs must not overwrite the current view.
+- Do not auto-focus the first row on load or reload.
+
+## Preferred Architecture
+
+Rust owns explorer behavior. Svelte renders the shell.
+
+- `crates/core`: IPC types, directory contracts, job scheduling, snapshot caching, cancellation, pure explorer logic.
+- `crates/platform-windows`: Windows-only filesystem integration, icon hydration, shell APIs, and future native context menu hooks.
+- `src-tauri`: Tauri host, commands, event emission, application wiring.
+- `src/`: SvelteKit UI shell, typed Tauri wrappers, stores, and components. No direct filesystem behavior.
+
+Frontend code should call typed wrappers under `src/lib/tauri/`. Tauri commands should expose serde-friendly contracts from Rust crates or host modules. New IPC contracts need matching Rust and TypeScript types.
+
+## File Organization
+
+The engineering handbook at [docs/handbook/](docs/handbook/) is the source of truth for code organization, file size, and hygiene. Skim its [README](docs/handbook/README.md) before making structural changes.
+
+Quick rules:
+
+- Feature-specific Svelte UI goes under `src/lib/components/<area>/` and related stores under `src/lib/stores/`.
+- Generic UI primitives stay under `src/lib/components/ui/`.
+- Typed frontend command wrappers stay under `src/lib/tauri/`.
+- Shared frontend types stay under `src/lib/types/`.
+- Rust explorer contracts and scheduling stay in `crates/core`.
+- Windows shell and filesystem code stays in `crates/platform-windows`.
+- Tauri command handlers stay under `src-tauri/src/commands/`; orchestration that is not a command handler belongs in a domain module such as `src-tauri/src/explorer/`.
+- A new top-level source directory needs a one-line entry in [docs/handbook/code-organization.md](docs/handbook/code-organization.md).
+
+Run through [docs/handbook/pr-checklist.md](docs/handbook/pr-checklist.md) before claiming implementation work complete.
+
+## Implementation Style
+
+- Prefer existing patterns over invention.
+- Keep changes scoped and reviewable.
+- Add abstractions only when they remove real duplication or protect a boundary already documented here.
+- Use Bun for frontend package management and scripts.
+- Commit `bun.lock` when frontend dependencies change.
+- Do not introduce dependencies without verifying the current stable version from an authoritative source and confirming they fit the project.
+- Do not add duplicate router, state, virtual list, command-wrapper, styling, or filesystem libraries without an ADR.
+- Add tests or checks where risk justifies them.
+- Use clear type names that match the docs unless there is a good reason to change them.
+- Add comments only for non-obvious architecture decisions.
+- Add TODOs for future features without implementing them early.
+
+## Quality Rules
+
+TypeScript:
+
+- No `as any`.
+- No `@ts-ignore`.
+- No `any` in function signatures.
+- No empty `catch` blocks.
+- No raw Tauri `invoke()` calls from components.
+
+Rust:
+
+- No `unwrap()` on `Result` in hot paths; propagate or handle.
+- New workspace crates need serde serialization for IPC contracts.
+- Platform-specific code stays behind `#[cfg(windows)]` gates or platform crates.
+- Long-running work must be cancellation-aware when it can race navigation.
+
+General:
+
+- UI never blocks on filesystem calls; all I/O goes through Rust via IPC.
+- All file operations initiated by UI emit through Rust commands.
+- Same-path refresh stages incoming items and swaps atomically on completion; do not clear the list.
+- Fast operations still need visible confirmation without flicker.
 
 ## Product UX Rules
 
-- Treat this as a Windows-first daily-driver file explorer, not a generic web app.
-- Match the system light/dark theme automatically by default.
-- Keep the shell visually closer to Files/Explorer than to dashboard-style web UIs.
-- Prefer compact, scan-friendly layouts over decorative styling.
+Theme and visual style:
 
-## Refresh And Loading Rules
+- Windows-first daily-driver shell, not a generic web app.
+- Match system light/dark theme automatically by default.
+- Visual style should sit closer to Explorer and Files than to dashboard UIs.
+- Keep layouts compact, scan-friendly, and quiet.
+- Do not use decorative cards, loud gradients, heavy blur, or web landing-page patterns in the working shell.
 
-- Refreshing the current folder must keep the current list visible until the replacement snapshot completes.
-- Same-path refreshes should stage incoming items and swap them in atomically on completion.
-- Do not clear the list for a same-path refresh.
-- Suppress transient loading UI for fast operations with a debounce.
-- Use subtle progress indication and skeletons instead of emptying stable content.
-- Footer/header loading text should avoid flicker on very fast operations.
+Refresh and loading:
 
-## Interaction Rules
+- Same-path refresh keeps the current list visible until the replacement snapshot completes.
+- Suppress transient loading UI with debounce.
+- Use subtle progress indication and skeletons over emptying stable content.
+- Loading text belongs in stable header/footer slots and must avoid layout shifts.
+
+Interaction:
 
 - Explorer chrome should not allow text selection except in real text inputs.
-- `Ctrl+A` inside the explorer shell should select visible items unless focus is in a text input.
-- Clicking empty list space should clear selection and focus outline.
-- Do not auto-focus the first row on load or reload.
-- Keep keyboard navigation working even when no row is currently focused.
+- `Ctrl+A` selects visible items unless focus is in a text input.
+- Clicking empty list space clears selection and focus outline.
+- Keyboard navigation works even when no row is currently focused.
+- Right-click, rename, selection, and drag/drop should follow Windows shell expectations.
 
-## Layout Rules
+Layout:
 
-- Keep nav controls, address bar, and search on one line.
-- Keep footer status in the bottom status bar, not the header.
+- Navigation controls, address bar, and search stay in a compact top area.
+- Footer status belongs in the bottom status bar, not the header.
 - Avoid layout shifts for transient controls or statuses.
-- Keep small gutters around list rows so future marquee selection has visual breathing room.
+- Keep small gutters around list rows so marquee selection has visual breathing room.
 
-## Feedback Rules
+Feedback:
 
-- Fast refreshes still need visible confirmation.
 - Reuse stable button slots instead of adding/removing controls during short-lived states.
 - Prefer subtle, native-feeling motion over flashy transitions.
+- Errors should explain the failed filesystem action without exposing irrelevant internal details.
+
+## Performance Rules
+
+- Navigation is incremental, cancelable, and benchmarked against [ROADMAP.md](ROADMAP.md) budgets.
+- Large lists are virtualized from day one.
+- Warm folder switches should show first visible rows quickly from cache or streamed deltas.
+- Stale navigation jobs never overwrite current view state.
+- Sorting and filtering for real directories stay Rust-owned.
+- Expensive enrichments are scheduled after the hot path and can be canceled.
+
+## Tauri Command Contracts
+
+- Every frontend filesystem operation goes through a typed wrapper in `src/lib/tauri/`.
+- Every new Tauri command needs a Rust serde model, a TypeScript type, and a typed frontend wrapper.
+- Command errors must serialize into user-visible application errors.
+- Do not add broad command payloads that expose arbitrary filesystem contents beyond the requested user action.
+- Do not add shell execution or process-spawning command surfaces without an ADR.
+
+## Security-Sensitive Changes
+
+Write an ADR before changing:
+
+- the frontend/Rust filesystem boundary
+- Tauri capabilities or plugin permissions
+- shell command execution policy
+- destructive file operation behavior
+- cross-platform backend abstractions
+- plugin or extension execution model
+- persistent storage of filesystem metadata, previews, hashes, or history
+- network, cloud, FTP/SFTP, or Git integrations that can affect navigation latency or credentials
+
+## Verification
+
+- Run the relevant checks before claiming work complete.
+- Frontend changes should pass `bun run check`.
+- Production build changes should pass `bun run build` when practical.
+- Rust backend changes should pass `cargo check`.
+- Rust behavior changes should run `cargo test` or a targeted crate test.
+- Tauri integration changes should be smoke tested with `bun run tauri dev` when practical.
+- If a check cannot run, state the exact blocker and what remains unverified.
+- When completing roadmap work, update the corresponding item in [ROADMAP.md](ROADMAP.md) or [TODOS.md](TODOS.md).
+
+## Git Workflow
+
+Before any git write, run:
+
+```sh
+git branch --show-current
+```
+
+If the current branch is `gitbutler/workspace`, this repo is in GitButler mode:
+
+- Use `but` for all git writes.
+- Never use raw `git add`, `git commit`, `git push`, `git checkout`, `git rebase`, `git merge`, or `git stash`.
+- Use `but diff --no-tui` for diffs.
+- Do not leave the workspace branch.
+- If `but` is missing or unclear, run `but --help`; do not fall back to raw git writes.
+- Before `but` commit, disable GitButler credit unless requested: `git config --local gitbutler.gitbutlerCommitter 0`.
+- Create PRs through `but pr new` when PR creation is requested.
+
+Outside GitButler mode, normal non-destructive git rules apply.
+
+Naming and commit rules:
+
+- Branch names use `feat/`, `fix/`, `refactor/`, `docs/`, `test/`, `chore/`, or `perf/` plus a concrete 2-6 word kebab-case slug.
+- Avoid vague branch names such as `tmp`, `misc`, `updates`, `stuff`, or ticket-only names.
+- Commit subjects should state one concrete outcome.
+- Add a short commit body only when the why is not obvious.
+- Do not add AI or coauthor attribution unless requested.
+- Avoid unrelated formatting churn.
+- Do not rewrite user changes.
+- Do not force push, amend, or rewrite history unless explicitly requested and safe.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,71 @@
+# Contributing
+
+This repo is a Windows-first Tauri 2 + SvelteKit + Rust file explorer. Contributions should preserve the central boundary: Rust owns filesystem behavior; Svelte renders typed state and sends typed user intent.
+
+## Start Here
+
+Before changing code, read:
+
+- [README.md](README.md) for setup and current state.
+- [docs/product-vision.md](docs/product-vision.md) for product direction.
+- [docs/architecture-blueprint.md](docs/architecture-blueprint.md) for module boundaries.
+- [docs/development-workflow.md](docs/development-workflow.md) for checks and testing expectations.
+- [docs/handbook/README.md](docs/handbook/README.md) for organization and hygiene rules.
+
+For UI work, also read [DESIGN.md](DESIGN.md).
+
+## Development Setup
+
+```sh
+bun install
+bun run tauri dev
+```
+
+Useful checks:
+
+```sh
+bun run check
+bun run build
+cargo check
+cargo test
+```
+
+## Contribution Rules
+
+- Keep diffs focused on one logical change.
+- Do not move filesystem behavior into Svelte.
+- Do not add dependencies without verifying the current stable version from an authoritative source.
+- Keep large lists virtualized.
+- Keep expensive enrichments off the navigation hot path.
+- Preserve same-path refresh behavior: keep current content visible until a replacement snapshot is ready.
+- Update [ROADMAP.md](ROADMAP.md) or [TODOS.md](TODOS.md) when a tracked item is completed.
+- Add an ADR under [docs/decisions/](docs/decisions/) before changing a locked-in boundary.
+
+## Git Workflow
+
+Before any git write, check the current branch:
+
+```sh
+git branch --show-current
+```
+
+If the branch is `gitbutler/workspace`, use GitButler for writes:
+
+- use `but` commands for add/commit/push/branch/PR operations
+- use `but diff --no-tui` for diffs
+- do not leave the workspace branch
+- do not fall back to raw git writes if `but` is unavailable
+
+Branch names should use a concrete prefix such as `feat/`, `fix/`, `docs/`, `refactor/`, `test/`, `chore/`, or `perf/`. Commit subjects should describe one concrete outcome. Do not add AI or coauthor attribution unless requested.
+
+## Pull Request Expectations
+
+Before opening a PR or handing work back, run through [docs/handbook/pr-checklist.md](docs/handbook/pr-checklist.md).
+
+At minimum, report:
+
+- what changed
+- what checks ran
+- what remains unverified, if anything
+
+Docs-only changes usually need link and content review rather than a full app build.

--- a/README.md
+++ b/README.md
@@ -2,56 +2,30 @@
 
 Windows-first file explorer rebooted from scratch as a Rust application with a thin Tauri renderer.
 
-## Product Direction
+**Goal:** feel like the file manager Windows should have shipped: native-feeling, theme-aware, compact, calm, modern, and visibly faster than Files.
 
-- Beat `Files` on perceived speed, not just binary size.
-- Keep all file-system logic in Rust.
-- Use Tauri and SvelteKit only as the UI renderer.
-- Optimize for Windows first while keeping Rust interfaces portable enough for future macOS/Linux backends.
+## Quick Start
 
-## Core Principles
+Requirements:
 
-- Navigation must be incremental, cancelable, and benchmarked.
-- The UI never owns sorting, searching, metadata hydration, or file operations.
-- Expensive enrichments such as thumbnails, Git state, hashes, preview generation, and cloud metadata stay off the hot path.
-- Large lists must be virtualized from day one.
+- Bun
+- Rust and Cargo
+- Tauri v2 system prerequisites for Windows
 
-## Current State
-
-This repo is a Tauri 2 + SvelteKit shell with Rust workspace crates for core IPC/job types, Windows platform file-system integration, and the Tauri host:
-
-- `Tauri 2`
-- `SvelteKit`
-- `TypeScript`
-- `bun`
-- `Rust`
-
-The current explorer slice includes Rust-backed streamed directory navigation, snapshot caching, cancellation, native icon hydration, a virtualized details list, breadcrumbs, tabs, keyboard selection/navigation, rename/delete/create-folder actions, Rust-owned sort/filter/search, and developer timing traces.
-
-Current product focus:
-
-- File operation queue with progress, cancellation, and conflict handling.
-- Performance metrics collection for startup, navigation, sort, search, and scroll budgets.
-- Dual-pane state model.
-- Native or shell-backed Windows context menu flow.
-- Full session restore across app restarts.
-
-## Planning Docs
-
-- `ROADMAP.md` - product and architecture roadmap
-- `TODOS.md` - implementation backlog for the next build phases
-
-## Why Svelte Here
-
-Svelte is a good fit for this architecture because the frontend is intentionally thin. It keeps renderer code smaller and simpler than a typical Vue setup while still being perfectly capable of hosting virtualized views, panes, tabs, and command surfaces.
-
-Vue would also work, but for a renderer-only desktop shell I would pick Svelte first unless your team already has strong Vue momentum.
-
-## Development
+Install dependencies and start the desktop app:
 
 ```sh
 bun install
 bun run tauri dev
+```
+
+Useful checks:
+
+```sh
+bun run check
+bun run build
+cargo check
+cargo test
 ```
 
 To artificially slow navigation for UI testing, set `VITE_EXPLORER_NAV_DELAY_MS` before starting dev.
@@ -63,6 +37,61 @@ $env:VITE_EXPLORER_NAV_DELAY_MS = "500"
 bun run tauri dev
 ```
 
-## Current Goal
+## What Works Today
 
-Move from fast single-pane navigation into daily-driver productivity: reliable file operations, measured performance, dual-pane workflows, shell-native actions, and restart-safe session restore.
+- Rust-backed streamed directory navigation
+- snapshot caching and cancellation-aware jobs
+- native Windows icon hydration
+- virtualized details list
+- breadcrumbs and path navigation
+- tabs
+- keyboard selection and navigation
+- rename, delete, and create-folder actions
+- Rust-owned sort, filter, and search
+- developer timing traces and artificial navigation delay controls
+
+## Product Direction
+
+- Beat Files on perceived speed, not just binary size.
+- Keep filesystem logic in Rust.
+- Use Tauri and SvelteKit as the UI renderer and app host.
+- Optimize for Windows first while keeping Rust interfaces portable enough for future macOS/Linux backends.
+- Preserve Explorer familiarity while improving visual clarity, theme behavior, and responsiveness.
+
+## Safety and Performance Model
+
+The frontend does not own filesystem behavior. Svelte sends typed user intent through Tauri wrappers; Rust owns directory enumeration, sorting, filtering, search, metadata hydration, cancellation, and file operations.
+
+Expensive enrichments such as thumbnails, Git state, hashes, preview generation, cloud metadata, archive inspection, and network providers stay off the navigation hot path. Large lists are virtualized from day one.
+
+## Stack
+
+- Tauri 2
+- SvelteKit and Svelte 5
+- TypeScript
+- Bun
+- Rust workspace crates
+- Windows shell/filesystem APIs through `crates/platform-windows`
+
+## Current Focus
+
+Move from fast single-pane navigation into daily-driver productivity:
+
+- file operation queue with progress, cancellation, and conflict handling
+- performance metrics collection for startup, navigation, sort, search, and scroll budgets
+- dual-pane state model
+- native or shell-backed Windows context menu flow
+- full session restore across app restarts
+
+## Docs
+
+See the [docs index](docs/README.md) for the full set, ordered by reading priority. Top entry points:
+
+- [Product Vision](docs/product-vision.md)
+- [Architecture Blueprint](docs/architecture-blueprint.md)
+- [Development Workflow](docs/development-workflow.md)
+- [Engineering Handbook](docs/handbook/README.md)
+- [Contributor Guide](CONTRIBUTING.md)
+- [Agent Guide](AGENTS.md)
+
+The design authority for UI work is [DESIGN.md](DESIGN.md). Roadmap tracking lives in [ROADMAP.md](ROADMAP.md) and near-term task tracking lives in [TODOS.md](TODOS.md).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,14 +2,22 @@
 
 ## Product Goal
 
-Build a Windows-first file explorer that feels faster than Files by keeping the hot path in Rust and using Tauri only as a renderer host.
+Build a Windows-first file explorer that feels faster than Files by keeping the hot path in Rust and using Tauri/Svelte as a thin desktop shell.
+
+## Reading Context
+
+- [Product Vision](docs/product-vision.md): product identity and UX posture.
+- [Architecture Blueprint](docs/architecture-blueprint.md): target module boundaries.
+- [Design Brief](DESIGN.md): visual and interaction authority.
+- [Development Workflow](docs/development-workflow.md): verification standard.
 
 ## Technical Strategy
 
 - Rust owns directory enumeration, sorting, filtering, search, file operations, archive handling, preview orchestration, caching, and job cancellation.
-- Tauri transports intents and incremental state updates.
-- Svelte renders panes, tabs, lists, omnibar, menus, and settings without owning file-system logic.
+- Tauri transports typed intents and incremental state updates.
+- Svelte renders panes, tabs, lists, path controls, menus, dialogs, and settings without owning filesystem logic.
 - Windows-specific integrations live behind platform modules so future macOS/Linux support can be added later without rewriting the core.
+- Expensive enrichments stay off the navigation hot path and must be cancelable when they can race navigation.
 
 ## Performance Budgets
 
@@ -20,51 +28,97 @@ Build a Windows-first file explorer that feels faster than Files by keeping the 
 - Scroll performance in details view: stable 60 fps in virtualized lists.
 - Cancellation: stale navigation jobs never overwrite current view state.
 
-## Phase 0 - Foundations
+## Phase 0: Foundations
 
-- Define Rust crate boundaries.
-- Define IPC model around request ids, job ids, and streamed deltas. Done for the first explorer slice.
-- Build benchmark harness for startup, navigation, search, sort, and file operations.
-- Lock down renderer-only frontend rules. Done for the current Tauri/Svelte shell.
+Goal: establish the repo and architecture boundary for a Rust-owned explorer.
 
-## Phase 1 - Fast Navigation Core
+- [x] Define Rust crate boundaries.
+- [x] Define IPC model around request ids, job ids, and streamed deltas for the first explorer slice.
+- [ ] Build benchmark harness for startup, navigation, search, sort, and file operations.
+- [x] Lock down renderer-only frontend rules for the current Tauri/Svelte shell.
+- [x] Add Kubecove-style docs, handbook, and ADR structure.
 
-- Create Rust directory engine with Windows-first enumeration. Done for the current single-pane explorer slice.
-- Return cheap item fields first, enrich later.
-- Add snapshot cache and cancellation-aware job scheduler. Done.
-- Build a virtualized details view in Svelte. Done.
-- Support basic selection, focus, keyboard navigation, and breadcrumbs. Done.
+## Phase 1: Fast Navigation Core
 
-## Phase 2 - Productivity Baseline
+Goal: make local directory navigation fast, incremental, and stable.
 
-- Add tabs. Done.
-- Add dual pane.
-- Add omnibar and command palette shell.
-- Add copy, move, rename, delete, recycle bin, and conflict UX.
-- Add fast in-folder filtering and sort specs powered by Rust. Done.
-- Add advanced/developer settings for artificial navigation delay and UI testing toggles. Done.
-- Add developer timing traces for navigation/render visibility. Done for development diagnostics; persistent metrics collection remains open.
+- [x] Create Rust directory engine with Windows-first enumeration for the current single-pane explorer slice.
+- [x] Return cheap item fields first and enrich later.
+- [x] Add snapshot cache and cancellation-aware job scheduler.
+- [x] Build a virtualized details view in Svelte.
+- [x] Support basic selection, focus, keyboard navigation, and breadcrumbs.
+- [x] Add Rust-owned in-folder filtering and sort specs.
 
-## Phase 3 - Rich File Workflows
+## Phase 2: Productivity Baseline
 
-- Add preview pane with lazy adapters.
-- Add archive browsing, extraction, and creation.
-- Add file properties and hashes.
-- Add session restore and advanced columns.
-- Add tags and keyboard remapping.
+Goal: become useful as a daily-driver shell for common file work.
 
-## Phase 4 - Integrations
+- [x] Add tabs.
+- [ ] Add dual-pane state model.
+- [ ] Add omnibar and command palette shell.
+- [ ] Add copy, move, rename, delete, recycle bin, and conflict UX.
+- [x] Add developer settings for artificial navigation delay and UI testing toggles.
+- [x] Add developer timing traces for navigation/render visibility.
+- [ ] Add persistent metrics collection for startup, navigation, sort, search, and scroll budgets.
+- [ ] Add native or shell-backed context menu flow.
+- [ ] Add full session restore across app restarts.
 
-- Add Git status and branch actions.
-- Add cloud drive providers without polluting core navigation latency.
-- Add FTP/SFTP.
-- Add third-party integration boundaries and plugin safety rules.
+## Phase 3: Rich File Workflows
 
-## Phase 5 - Future Portability
+Goal: add deeper file management without slowing the navigation hot path.
 
-- Extract Windows assumptions into platform modules.
-- Add portable core tests.
-- Introduce macOS/Linux backends only after Windows performance targets are consistently met.
+- [ ] Add preview pane with lazy adapters.
+- [ ] Add archive browsing, extraction, and creation.
+- [ ] Add file properties and hashes.
+- [ ] Add advanced columns.
+- [ ] Add tags.
+- [ ] Add keyboard remapping.
+
+## Phase 4: Integrations
+
+Goal: add optional external context behind explicit boundaries.
+
+- [ ] Add Git status and branch actions.
+- [ ] Add cloud drive providers without polluting core navigation latency.
+- [ ] Add FTP/SFTP.
+- [ ] Define third-party integration boundaries and plugin safety rules.
+- [ ] Add ADRs for any integration that touches credentials, shell execution, or the navigation hot path.
+
+## Phase 5: Future Portability
+
+Goal: preserve Windows excellence while making future platform backends possible.
+
+- [ ] Extract remaining Windows assumptions into platform modules.
+- [ ] Add portable core tests.
+- [ ] Define platform backend contracts.
+- [ ] Introduce macOS/Linux backends only after Windows performance targets are consistently met.
+
+## Cross-Cutting Tracks
+
+### Safety and File Operations
+
+- [x] Keep frontend filesystem behavior behind Tauri commands.
+- [x] Keep first navigation slice Rust-owned.
+- [ ] Make destructive operations queue-aware and progress-reporting.
+- [ ] Prefer recycle-bin behavior where Windows supports it.
+- [ ] Add ADR before exposing broad shell execution or plugin execution.
+
+### UX and Shell Fidelity
+
+- [x] Match system light/dark theme by default.
+- [x] Keep the main list virtualized.
+- [x] Keep same-path refresh stable rather than clearing the list.
+- [ ] Add shell-native context menu behavior.
+- [ ] Add drag/drop affordances.
+- [ ] Add dual-pane workflows.
+
+### Agent and Maintainer Discipline
+
+- [x] Add docs index and agent guide.
+- [x] Add engineering handbook.
+- [x] Add architecture decision records directory.
+- [ ] Add checked-in pre-commit or validation hook if the repo starts needing enforced size/secrets checks.
+- [ ] Keep roadmap/TODO items updated as milestones land.
 
 ## Non-Negotiables
 
@@ -73,3 +127,4 @@ Build a Windows-first file explorer that feels faster than Files by keeping the 
 - No heavy metadata on first paint.
 - No UI-thread sorting for real directories.
 - No long-running integrations inline with navigation.
+- No frontend-owned filesystem operations.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,32 @@
+# Docs Index
+
+Documentation for the Windows-first file explorer. Read in roughly this order: product intent first, then architecture constraints, then workflow and tracking.
+
+## Start here
+
+- [Product Vision](product-vision.md): what this app is, who it is for, UX posture, performance posture, and Windows shell expectations.
+- [Architecture Blueprint](architecture-blueprint.md): Rust/Svelte/Tauri boundaries, module layout, IPC contracts, and future extension points.
+- [Design Brief](../DESIGN.md): visual and interaction authority for the Explorer-like shell.
+
+## Conventions and handbook
+
+- [Engineering Handbook](handbook/): code organization, file-size guidance, hygiene rules, and completion checklist.
+- [Development Workflow](development-workflow.md): Bun/Cargo commands, verification expectations, and testing standard.
+- [Contributor Guide](../CONTRIBUTING.md): human contributor entry point for setup, scope, checks, and PR expectations.
+
+## Constraints and decisions
+
+- [Architecture Decision Records](decisions/): decisions that require a new ADR to change.
+- [Agent Guide](../AGENTS.md): agent-facing rules, command contracts, UX rules, ADR triggers, and verification expectations.
+
+## Work tracking
+
+- [Roadmap](../ROADMAP.md): product phases, performance budgets, and non-negotiables.
+- [TODOs](../TODOS.md): near-term implementation backlog.
+- [Release Notes and Flow](release.md): maintainer release expectations for future beta builds.
+
+## Reading shortcuts
+
+- Editing UI shell behavior: read [Product Vision](product-vision.md), [Design Brief](../DESIGN.md), and [handbook/code-organization.md](handbook/code-organization.md).
+- Editing Rust filesystem behavior: read [Architecture Blueprint](architecture-blueprint.md), [Development Workflow](development-workflow.md), and [decisions/0001-rust-owned-filesystem-boundary.md](decisions/0001-rust-owned-filesystem-boundary.md).
+- Finishing an agent task: read [handbook/pr-checklist.md](handbook/pr-checklist.md).

--- a/docs/architecture-blueprint.md
+++ b/docs/architecture-blueprint.md
@@ -1,0 +1,154 @@
+# Architecture Blueprint
+
+This document describes the target shape of the code. For the rules around file size, folder ownership, and hygiene, see the [engineering handbook](handbook/).
+
+## Product Direction
+
+File Explorer is a Windows-first Tauri desktop shell with Rust-owned filesystem behavior. The renderer is intentionally thin: it displays typed state, sends typed user intents, and avoids owning filesystem policy.
+
+The core flow is:
+
+```text
+User intent -> Svelte UI -> typed Tauri wrapper -> Rust command -> core/platform service -> streamed UI state
+```
+
+## Frontend/Rust Boundary
+
+The frontend is a renderer and interaction layer. It must not:
+
+- enumerate directories
+- sort or search real directory contents
+- hydrate metadata from the filesystem
+- execute shell commands
+- perform copy, move, rename, delete, recycle, or create-folder operations directly
+- block the UI while waiting for filesystem I/O
+
+The Rust side owns:
+
+- directory enumeration
+- sorting, filtering, and search for real directories
+- metadata contracts
+- icon hydration coordination
+- cancellation and job scheduling
+- file operations
+- platform integration
+
+## Rust Workspace Shape
+
+```text
+crates/
+  core/
+    src/
+      explorer/
+      ipc/
+  platform-windows/
+    src/
+      windows/
+src-tauri/
+  src/
+    commands/
+    explorer/
+```
+
+Responsibilities:
+
+- `crates/core`: portable explorer contracts, IPC types, job scheduling, snapshot caching, cancellation, pure sort/filter/search logic when it is not platform-specific.
+- `crates/platform-windows`: Windows filesystem enumeration, shell metadata, native icon hydration, recycle-bin/context-menu integration, and Windows API boundaries.
+- `src-tauri/src/commands`: small Tauri command handlers and validation.
+- `src-tauri/src/explorer`: host-side orchestration that wires commands to core and platform services.
+
+Future platform crates such as `platform-macos` or `platform-linux` should match the core contracts rather than forcing the UI to understand platform details.
+
+## Frontend Shape
+
+```text
+src/
+  lib/
+    components/
+      explorer/
+      settings/
+      ui/
+      window/
+    stores/
+    tauri/
+    types/
+    utils/
+  routes/
+```
+
+Responsibilities:
+
+- `components/explorer`: Explorer-specific UI shell, panes, rows, command bars, context menus, and status surfaces.
+- `components/settings`: settings UI and related controls.
+- `components/ui`: generic primitives with no explorer-specific behavior.
+- `components/window`: window chrome and app frame.
+- `stores`: UI state, session state, workspace state, settings, dialogs, notifications, and action orchestration.
+- `tauri`: typed frontend wrappers around Tauri commands.
+- `types`: frontend copies of IPC contracts.
+- `utils`: pure frontend helpers only.
+
+## Tauri Command Contracts
+
+Every command should have:
+
+- a Rust serde model or existing shared model
+- a TypeScript type
+- a typed frontend wrapper
+- serialized errors suitable for user-facing UI
+- cancellation or request identity when it can race navigation
+
+Commands should be narrow. Prefer intent-shaped commands over broad "do anything" payloads.
+
+## Navigation and Refresh
+
+Navigation uses request/job identity so stale results cannot replace current state.
+
+Same-path refresh behavior:
+
+1. Keep the current list visible.
+2. Start a replacement snapshot.
+3. Stage incoming rows while work is in progress.
+4. Swap atomically when the replacement snapshot completes.
+5. Preserve selection/focus where the refreshed data still supports it.
+
+Fast refreshes still get confirmation through stable status surfaces, not layout-shifting spinners.
+
+## File Operation Strategy
+
+File operations should flow through Rust commands and future queue orchestration:
+
+- create folder
+- rename
+- delete/recycle
+- copy
+- move
+- conflict handling
+- cancellation
+- progress reporting
+
+The UI displays operation state; Rust owns execution and filesystem error handling.
+
+## Performance Budgets
+
+The roadmap owns specific numbers. Architecture must preserve the conditions that make those budgets possible:
+
+- streamed directory deltas
+- virtualized lists
+- cheap fields before expensive enrichments
+- snapshot caching
+- cancelable jobs
+- no UI-thread sorting/searching for real directories
+
+## Future Extension Points
+
+- dual-pane workspace model
+- preview adapters
+- archive browsing
+- properties and hashes
+- Git integration
+- cloud providers
+- FTP/SFTP
+- plugin boundaries
+- cross-platform backends
+
+Each extension must define whether it runs on the hot path, how it is canceled, what it caches, and what data crosses the Tauri boundary.

--- a/docs/decisions/0001-rust-owned-filesystem-boundary.md
+++ b/docs/decisions/0001-rust-owned-filesystem-boundary.md
@@ -1,0 +1,28 @@
+# ADR 0001: Rust-Owned Filesystem Boundary
+
+## Status
+
+Accepted.
+
+## Context
+
+The app is a desktop file explorer. It will browse large folders, manipulate real user files, integrate with Windows shell behavior, and eventually coordinate previews, archives, Git state, cloud providers, and network filesystems.
+
+If the frontend owns filesystem behavior, the product becomes harder to secure, harder to make cancelable, and easier to slow down with renderer-thread work.
+
+## Decision
+
+The Rust side owns filesystem behavior.
+
+- Svelte renders typed state and sends typed user intents.
+- Tauri commands are the only path from UI intent to filesystem work.
+- Directory enumeration, sorting, filtering, search, metadata hydration, and file operations live in Rust.
+- Windows-specific filesystem and shell integration lives in `crates/platform-windows`.
+- The renderer never executes arbitrary shell commands.
+- Expensive enrichments stay off the navigation hot path.
+
+## Consequences
+
+This creates a stricter boundary than a typical desktop webview app. It may take more plumbing to add features, but navigation stays faster, cancellation is reliable, and future platform backends can share the same core contracts.
+
+Changing this boundary requires a new ADR.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -1,0 +1,22 @@
+# Architecture Decision Records
+
+ADRs capture decisions that should not change accidentally during normal feature work.
+
+## Current ADRs
+
+- [0001: Rust-Owned Filesystem Boundary](0001-rust-owned-filesystem-boundary.md)
+
+## When to add an ADR
+
+Add an ADR before changing:
+
+- the frontend/Rust filesystem boundary
+- Tauri capabilities or plugin permissions
+- shell command execution policy
+- destructive file operation behavior
+- cross-platform backend abstractions
+- plugin or extension execution model
+- persistent storage of filesystem metadata, previews, hashes, or history
+- network, cloud, FTP/SFTP, or Git integrations that can affect navigation latency or credentials
+
+Keep ADRs short: context, decision, consequences.

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -1,0 +1,85 @@
+# Development Workflow
+
+## Package Manager
+
+Use Bun for frontend package management, scripts, and scaffolding.
+
+Install dependencies and start the Tauri app:
+
+```sh
+bun install
+bun run tauri dev
+```
+
+Useful frontend commands:
+
+```sh
+bun run check
+bun run build
+```
+
+Rust checks:
+
+```sh
+cargo check
+cargo test
+```
+
+To artificially slow navigation for UI testing, set `VITE_EXPLORER_NAV_DELAY_MS` before starting dev.
+
+PowerShell example:
+
+```powershell
+$env:VITE_EXPLORER_NAV_DELAY_MS = "500"
+bun run tauri dev
+```
+
+## Dependency Policy
+
+Use the latest stable version by default. Before adding, installing, upgrading, or recommending dependencies, APIs, SDKs, CLIs, frameworks, runtimes, templates, or external services, verify the current stable version from an authoritative source.
+
+Preferred sources:
+
+- `bun pm` or registry metadata for frontend packages
+- `cargo search`, `cargo info`, or crates.io for Rust crates
+- official docs or release pages for Tauri, SvelteKit, Bun, Rust, and Windows APIs
+
+If the latest stable version conflicts with project constraints, choose the newest compatible version and document why.
+
+## Testing Standard
+
+Tests should prove behavior, contracts, or invariants. Avoid tests that simply mirror implementation branches.
+
+Use focused example tests for regressions and user-visible behavior. Use contract tests when IPC shapes or frontend wrappers can drift. Use property-style tests for pure deterministic logic with compact invariants, such as sort specs, path normalization, selection math, and cache-key behavior.
+
+Do not require property tests for Svelte rendering, native Windows shell integration, or Tauri commands that need live OS state unless the risk justifies the setup.
+
+## Verification Before Completion
+
+Before claiming a task is complete, run the checks that prove it:
+
+- docs-only change: inspect links and headings; no build is usually required
+- frontend change: `bun run check`
+- production build or routing/static output change: `bun run build`
+- Rust backend change: `cargo check`
+- Rust behavior change: `cargo test` or targeted crate tests
+- Tauri integration change: `bun run tauri dev` smoke test when practical
+
+If a check cannot run locally, say exactly why and what remains unverified.
+
+## Manual Smoke Areas
+
+For UI or Tauri changes, smoke the affected path:
+
+- launch app
+- navigate to a normal folder
+- navigate to a large folder
+- sort and filter/search
+- refresh the same path
+- select with mouse and keyboard
+- verify stale navigation does not overwrite current rows
+- verify error UI with an unavailable path when relevant
+
+## Completion Tracking
+
+When work completes a roadmap or TODO item, update [ROADMAP.md](../ROADMAP.md) or [TODOS.md](../TODOS.md) in the same change. Do not tick items early.

--- a/docs/handbook/README.md
+++ b/docs/handbook/README.md
@@ -1,0 +1,18 @@
+# Engineering Handbook
+
+Short, canonical rules for working in this repo. The handbook is the source of truth for organization, file size, hygiene, and completion checks. If another doc contradicts the handbook, fix the contradiction.
+
+## When to consult what
+
+- About to add a file or folder: [code-organization.md](code-organization.md).
+- A file is getting long: [file-size-and-split.md](file-size-and-split.md).
+- About to replace, rename, or remove something: [hygiene.md](hygiene.md).
+- About to finish an agent task or open a PR: [pr-checklist.md](pr-checklist.md).
+
+## What this handbook is not
+
+- Not the product vision: see [product-vision.md](../product-vision.md).
+- Not the architecture target: see [architecture-blueprint.md](../architecture-blueprint.md).
+- Not locked-in decisions: see [decisions/](../decisions/).
+
+Keep handbook pages short enough to read quickly before editing.

--- a/docs/handbook/code-organization.md
+++ b/docs/handbook/code-organization.md
@@ -1,0 +1,67 @@
+# Code Organization
+
+Where things go. The target shape lives in [architecture-blueprint.md](../architecture-blueprint.md); this page is the rules.
+
+## Frontend (`src/`)
+
+### `src/lib/components/explorer/`
+
+Explorer-specific UI: shell layout, panes, rows, headers, breadcrumbs, command bars, context menus, loading/error/empty states, and status bar.
+
+### `src/lib/components/settings/`
+
+Settings dialogs and controls. Settings persistence helpers belong in stores or pure helpers, not inside visual components.
+
+### `src/lib/components/ui/`
+
+Generic, feature-agnostic primitives only. A component does not belong here if it is used only by the explorer surface.
+
+### `src/lib/components/window/`
+
+Window chrome and frame-level UI.
+
+### `src/lib/stores/`
+
+Svelte stores for UI state, session state, workspace state, settings, notifications, dialogs, and action orchestration. Stores may coordinate Tauri calls but must not implement filesystem logic that belongs in Rust.
+
+### `src/lib/tauri/`
+
+Typed wrappers around Tauri commands. Components should import wrappers from here instead of calling raw `invoke()`.
+
+### `src/lib/types/`
+
+Frontend copies of Rust IPC contracts and action types.
+
+### `src/lib/utils/`
+
+Pure frontend utilities. No filesystem access, no Tauri invoke calls, and no component code.
+
+## Rust (`crates/` and `src-tauri/`)
+
+### `crates/core/`
+
+Portable explorer contracts and logic: IPC types, directory snapshots, job scheduling, cancellation, sorting/filtering/searching contracts, and cache-friendly models.
+
+### `crates/platform-windows/`
+
+Windows-specific filesystem and shell integration. Windows API details stay here and should not leak into frontend code.
+
+### `src-tauri/src/commands/`
+
+Small Tauri command handlers. Commands validate input, call domain services, and serialize results/errors. They should not grow into large filesystem engines.
+
+### `src-tauri/src/explorer/`
+
+Host-side explorer orchestration that connects commands, core models, and platform services.
+
+## New top-level directories
+
+Adding a new top-level source directory under `src/`, `crates/`, or `src-tauri/src/` requires a one-line entry in this file before the directory becomes a pattern.
+
+## Cross-cutting rules
+
+- Frontend never performs real filesystem work directly.
+- Frontend never executes shell commands.
+- Tauri command wrappers stay typed.
+- Platform-specific code stays behind platform crates or `#[cfg]` gates.
+- Security-sensitive boundary changes require an ADR.

--- a/docs/handbook/file-size-and-split.md
+++ b/docs/handbook/file-size-and-split.md
@@ -1,0 +1,47 @@
+# File Size and Split Triggers
+
+Long files are harder to review, harder for agents to edit safely, and more likely to hide duplicated behavior. These caps are guidance until a hook enforces them.
+
+## Caps
+
+| Extension | Soft | Hard |
+| --- | ---: | ---: |
+| `.rs` | 500 lines | 800 lines |
+| `.svelte` | 400 lines | 700 lines |
+| `.ts` | 300 lines | 600 lines |
+| `.css` | 400 lines | 700 lines |
+
+Tests, generated files, declarations, lockfiles, `node_modules/**`, `.svelte-kit/**`, `target/**`, and `src-tauri/target/**` are exempt.
+
+## What the caps mean
+
+- Soft cap: plan a split the next time the file is touched for structural work.
+- Hard cap: split before adding substantial new behavior.
+
+## How to split
+
+Rust:
+
+- Move related command handlers into per-domain files under `src-tauri/src/commands/`.
+- Move portable logic into `crates/core` instead of growing Tauri host files.
+- Move Windows-only logic into `crates/platform-windows`.
+- Keep `mod.rs` files as routing surfaces, not dumping grounds.
+
+Svelte:
+
+- Pull repeated row/header/dialog pieces into sibling components inside the same feature folder.
+- Move pure logic into a store, helper, or `src/lib/utils/` when it is genuinely reusable.
+- Keep component files focused on rendering and local interaction wiring.
+
+TypeScript:
+
+- Split stores when a state domain gets independent actions and invariants.
+- Keep IPC types grouped by domain.
+- Keep typed Tauri wrappers small and command-shaped.
+
+## Do not
+
+- Do not split by line count alone.
+- Do not create one-import wrappers just to dodge a cap.
+- Do not leave old files behind "for reference."
+- Do not add new oversized files and call them legacy.

--- a/docs/handbook/hygiene.md
+++ b/docs/handbook/hygiene.md
@@ -1,0 +1,44 @@
+# Hygiene
+
+Rules for keeping the codebase free of dead, duplicate, and orphaned code.
+
+## Orphan files
+
+An orphan file is a source file with no inbound import from production code, excluding tests and deliberate examples.
+
+- Delete orphan files in the same change that creates or discovers them.
+- Do not keep "for reference" copies. Git history is the reference.
+- Do not leave renamed-and-kept stubs unless an external consumer truly depends on the old path.
+
+## Superseding a file
+
+When a change replaces a component, function, store, or module:
+
+- Delete the predecessor in the same change.
+- Remove commented-out blocks and placeholder exports.
+- Keep transition shims only when there is a real external compatibility reason.
+
+## Duplicate components and helpers
+
+Avoid parallel implementations of the same concept:
+
+- two file list rows
+- two context menu systems
+- two notification hosts
+- two path formatters
+- two Tauri wrappers for the same command
+- two sort/search implementations
+
+If duplication is intentional during a migration, document the migration endpoint and keep it short-lived.
+
+## Dead code inside a file
+
+- Delete unused imports, unused exports, unreachable branches, and commented-out blocks.
+- Do not suppress Rust dead-code warnings without a written reason.
+- Do not use TypeScript type escapes to keep dead paths compiling.
+
+## What is deliberately allowed
+
+- TODO comments tied to a roadmap, ADR, or follow-up task.
+- Disabled capability flags that are wired through for a documented future feature.
+- Small example fixtures when they prove a reusable contract.

--- a/docs/handbook/pr-checklist.md
+++ b/docs/handbook/pr-checklist.md
@@ -1,0 +1,40 @@
+# PR / Agent Checklist
+
+Run through this before opening a PR or marking an agent task done.
+
+## Verification
+
+- [ ] `bun run check` passes if frontend code changed.
+- [ ] `bun run build` passes if build output, routing, or production behavior changed.
+- [ ] `cargo check` passes if Rust code changed.
+- [ ] Relevant `cargo test` or targeted tests pass if behavior changed.
+- [ ] The app starts and the affected flow works if Tauri integration changed.
+
+## Architecture
+
+- [ ] Frontend did not take ownership of filesystem work.
+- [ ] New Tauri commands have typed wrappers and typed IPC contracts.
+- [ ] Rust code is in the correct crate or host module.
+- [ ] Windows-specific code stayed in `crates/platform-windows` or behind `#[cfg(windows)]`.
+
+## UX and Performance
+
+- [ ] Large lists remain virtualized.
+- [ ] Same-path refresh does not clear stable content.
+- [ ] Loading and status UI does not cause layout shift.
+- [ ] No expensive enrichment moved onto the navigation hot path.
+- [ ] Keyboard selection and focus rules still match the agent guide.
+
+## Organization
+
+- [ ] New files follow [code-organization.md](code-organization.md).
+- [ ] Files crossing the soft caps have a split plan.
+- [ ] No hard-cap file grew without being split.
+- [ ] Superseded files were deleted.
+- [ ] No duplicate component, store, wrapper, or helper was added.
+
+## Tracking
+
+- [ ] Completed roadmap/TODO items were updated.
+- [ ] Security-sensitive boundary changes have an ADR under [decisions/](../decisions/).
+- [ ] Verification evidence is reported in the final response or PR description.

--- a/docs/product-vision.md
+++ b/docs/product-vision.md
@@ -1,0 +1,106 @@
+# Product Vision
+
+## Identity
+
+File Explorer is a Windows-first desktop file manager built around a Rust filesystem core and a thin Tauri/Svelte renderer. It is not a generic web app in a desktop wrapper and it is not trying to be a flashy alternative file manager.
+
+The product personality is **native speed with quiet control**: fast enough to feel shell-level, familiar enough for daily Explorer users, and disciplined enough that heavy metadata or integrations never slow down ordinary navigation.
+
+## Product Positioning
+
+The app should feel like the file manager Windows should have shipped: native-feeling, theme-aware, compact, calm, modern, and visibly faster than Files.
+
+Explorer is the behavioral baseline. Files is useful inspiration for cleanliness and polish, but this project must avoid Files' visual heaviness and perceived latency.
+
+## Core Jobs
+
+Three jobs drive feature decisions:
+
+1. Browse local folders quickly, including large directories.
+2. Perform everyday file operations with reliable progress, cancellation, and conflict handling.
+3. Keep power-user navigation efficient through tabs, panes, keyboard selection, shell actions, and restart-safe session restore.
+
+## Navigation Model
+
+Navigation is path-first and shell-familiar:
+
+```text
+Window -> Tab -> Pane -> Directory snapshot -> Selection/focus
+```
+
+The current path, selection, and visible rows should remain stable through refreshes. Same-path refreshes stage incoming data and swap atomically only when the replacement snapshot is ready.
+
+The UI should support:
+
+- breadcrumb/path navigation
+- keyboard navigation even without a focused row
+- `Ctrl+A` selection for visible items
+- empty-space click to clear selection
+- tabs as lightweight shell utilities
+- future dual-pane workflows without changing the core navigation model
+
+## Safety Posture
+
+The app will eventually perform destructive operations. Those actions must be deliberate, typed, and Rust-owned.
+
+- Svelte sends user intent.
+- Rust validates and executes filesystem operations.
+- UI state reflects progress, cancellation, conflicts, and errors.
+- Destructive flows must have clear confirmation or undo/recycle-bin behavior where Windows supports it.
+
+No frontend component should directly perform filesystem operations or shell execution.
+
+## Performance Posture
+
+The app exists because perceived speed matters. The hot path is directory navigation:
+
+- enumerate cheap fields first
+- stream incremental rows
+- virtualize large lists
+- cache snapshots where useful
+- cancel stale jobs
+- defer heavy enrichments
+
+Features such as thumbnails, Git status, hashes, archive previews, cloud metadata, and network providers are valuable only when they do not pollute first paint or block navigation.
+
+## Visual Emphasis
+
+The default working surface is a compact Explorer-like shell:
+
+- left navigation sidebar
+- top navigation/path/search controls
+- main virtualized details list
+- bottom status bar
+
+The file list is the center of gravity. Filenames should be visually strongest; size, date, type, and secondary metadata should be quieter. Selection, hover, and focus states must be obvious without being loud.
+
+## Theme Strategy
+
+The default theme follows the Windows system theme. Manual light/dark overrides are acceptable, but both modes must feel designed rather than inverted.
+
+Avoid decorative chrome, excessive blur, oversized shadows, loud gradients, and card-heavy layouts. Use restrained layered surfaces and native-feeling controls.
+
+## Near-Term Implications
+
+The next product work should turn the fast single-pane browser into a daily-driver baseline:
+
+- file operation queue with progress, cancellation, and conflict handling
+- dual-pane model
+- shell-backed context menu flow
+- startup/navigation/sort/search/scroll metrics
+- full session restore across app restarts
+
+## Long-Term Implications
+
+Later milestones can add:
+
+- preview pane and lazy preview adapters
+- archive browsing and creation
+- file properties and hashes
+- Git state and actions
+- cloud providers
+- FTP/SFTP
+- plugin or extension boundaries
+- macOS/Linux platform backends
+
+Each extension follows the same principle: protect local navigation speed, keep file operations Rust-owned, and make integration boundaries explicit.

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,35 @@
+# Releases
+
+The project is not yet release-managed like a packaged beta product. This document defines the expected maintainer flow once installers are published.
+
+## Release Readiness
+
+A release candidate should have:
+
+- passing `bun run check`
+- passing `bun run build`
+- passing `cargo check`
+- passing relevant `cargo test` coverage
+- a manual Tauri smoke test on Windows
+- updated roadmap/TODO tracking for completed scope
+- no known navigation, refresh, or destructive file-operation regressions
+
+## Future Maintainer Release Flow
+
+1. Update versions in `package.json`, `src-tauri/tauri.conf.json`, and Rust manifests as needed.
+2. Update release notes or changelog when one exists.
+3. Run the release readiness checks.
+4. Build the Tauri bundle.
+5. Smoke test the installer or built app on Windows.
+6. Publish the release only after artifact checks pass.
+
+## Publishing Checklist
+
+- Confirm Windows artifacts exist and launch.
+- Confirm basic navigation works in user directories.
+- Confirm large folder navigation remains responsive.
+- Confirm rename/delete/create-folder flows behave as expected if touched.
+- Confirm errors are understandable when a folder is missing or inaccessible.
+- Confirm no debug-only artificial delay or tracing setting is accidentally enabled by default.
+
+Future macOS/Linux releases should wait until platform backends are intentionally supported.


### PR DESCRIPTION
## Summary
- Add a Kubecove-style docs index, product vision, architecture blueprint, handbook, ADR, release, and contributor docs.
- Expand AGENTS.md with project-specific agent rules, GitButler workflow, UX, architecture, verification, and dependency policy.
- Refresh README and ROADMAP to point at the new docs structure and current project direction.

## Testing
- Project markdown relative links OK
- No trailing whitespace in project docs
- git diff --check -- AGENTS.md README.md ROADMAP.md CONTRIBUTING.md docs

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #13 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #12
<!-- GitButler Footer Boundary Bottom -->