### PR TITLE
Restructure explorer architecture boundaries

### DIFF
--- a/crates/core/src/explorer/mod.rs
+++ b/crates/core/src/explorer/mod.rs
@@ -1,1 +1,2 @@
 pub mod jobs;
+pub mod projection;

--- a/crates/core/src/explorer/projection.rs
+++ b/crates/core/src/explorer/projection.rs
@@ -1,0 +1,175 @@
+use crate::directory::{DirectoryItemKind, DirectoryItemStub, SortDirection, SortField, SortSpec};
+use std::cmp::Ordering;
+
+pub fn project_directory_snapshot(
+    items: &[DirectoryItemStub],
+    query: Option<&str>,
+    sort: Option<SortSpec>,
+) -> Vec<DirectoryItemStub> {
+    let normalized_query = normalize_query(query);
+    let mut projected_items = items
+        .iter()
+        .filter(|item| matches_query(item, normalized_query.as_deref()))
+        .cloned()
+        .collect::<Vec<_>>();
+
+    sort_directory_items(&mut projected_items, &sort.unwrap_or(default_sort_spec()));
+    projected_items
+}
+
+fn normalize_query(query: Option<&str>) -> Option<String> {
+    let trimmed_query = query.unwrap_or_default().trim();
+    if trimmed_query.is_empty() {
+        return None;
+    }
+
+    Some(trimmed_query.to_ascii_lowercase())
+}
+
+fn matches_query(item: &DirectoryItemStub, normalized_query: Option<&str>) -> bool {
+    let Some(normalized_query) = normalized_query else {
+        return true;
+    };
+
+    format!(
+        "{} {} {}",
+        item.name,
+        searchable_kind_label(&item.kind),
+        item.path
+    )
+    .to_ascii_lowercase()
+    .contains(normalized_query)
+}
+
+fn sort_directory_items(items: &mut [DirectoryItemStub], sort_spec: &SortSpec) {
+    items.sort_by(|left, right| compare_directory_items(left, right, sort_spec));
+}
+
+fn compare_directory_items(
+    left: &DirectoryItemStub,
+    right: &DirectoryItemStub,
+    sort_spec: &SortSpec,
+) -> Ordering {
+    let left_is_folder_group = matches!(
+        left.kind,
+        DirectoryItemKind::Directory | DirectoryItemKind::Symlink
+    );
+    let right_is_folder_group = matches!(
+        right.kind,
+        DirectoryItemKind::Directory | DirectoryItemKind::Symlink
+    );
+
+    let directory_bias = match (left_is_folder_group, right_is_folder_group) {
+        (true, false) => Ordering::Less,
+        (false, true) => Ordering::Greater,
+        _ => Ordering::Equal,
+    };
+
+    if directory_bias != Ordering::Equal {
+        return directory_bias;
+    }
+
+    let ordering = match sort_spec.field {
+        SortField::Name => left
+            .name
+            .to_ascii_lowercase()
+            .cmp(&right.name.to_ascii_lowercase()),
+        SortField::Type => type_label(&left.kind).cmp(type_label(&right.kind)),
+        SortField::ModifiedAt => left.modified_at.cmp(&right.modified_at),
+        SortField::Size => left.size.cmp(&right.size),
+    };
+
+    let ordering = if ordering == Ordering::Equal {
+        left.name
+            .to_ascii_lowercase()
+            .cmp(&right.name.to_ascii_lowercase())
+    } else {
+        ordering
+    };
+
+    match sort_spec.direction {
+        SortDirection::Asc => ordering,
+        SortDirection::Desc => ordering.reverse(),
+    }
+}
+
+fn default_sort_spec() -> SortSpec {
+    SortSpec {
+        field: SortField::Type,
+        direction: SortDirection::Asc,
+    }
+}
+
+fn searchable_kind_label(kind: &DirectoryItemKind) -> &'static str {
+    match kind {
+        DirectoryItemKind::Directory => "directory",
+        DirectoryItemKind::File => "file",
+        DirectoryItemKind::Symlink => "symlink",
+        DirectoryItemKind::Other => "other",
+    }
+}
+
+fn type_label(kind: &DirectoryItemKind) -> &'static str {
+    match kind {
+        DirectoryItemKind::Directory => "Folder",
+        DirectoryItemKind::File => "File",
+        DirectoryItemKind::Symlink => "Shortcut",
+        DirectoryItemKind::Other => "Other",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::directory::NativeIconState;
+
+    fn item(name: &str, path: &str, kind: DirectoryItemKind) -> DirectoryItemStub {
+        DirectoryItemStub {
+            id: path.to_string(),
+            name: name.to_string(),
+            path: path.to_string(),
+            kind,
+            size: None,
+            modified_at: None,
+            hidden: false,
+            readonly: false,
+            icon_data_url: None,
+            native_icon_state: NativeIconState::Pending,
+        }
+    }
+
+    #[test]
+    fn project_directory_snapshot_filters_without_mutating_source_items() {
+        let items = vec![
+            item("Alpha", r"C:\\Work\\Alpha.txt", DirectoryItemKind::File),
+            item("Beta", r"C:\\Work\\Beta", DirectoryItemKind::Directory),
+        ];
+
+        let projected = project_directory_snapshot(&items, Some("beta"), None);
+
+        assert_eq!(projected, vec![items[1].clone()]);
+        assert_eq!(items.len(), 2);
+    }
+
+    #[test]
+    fn project_directory_snapshot_keeps_directories_grouped_when_sorting_by_name_desc() {
+        let items = vec![
+            item("alpha.txt", r"C:\\Work\\alpha.txt", DirectoryItemKind::File),
+            item("Zoo", r"C:\\Work\\Zoo", DirectoryItemKind::Directory),
+            item("Beta", r"C:\\Work\\Beta", DirectoryItemKind::Directory),
+        ];
+
+        let projected = project_directory_snapshot(
+            &items,
+            None,
+            Some(SortSpec {
+                field: SortField::Name,
+                direction: SortDirection::Desc,
+            }),
+        );
+
+        assert_eq!(projected[0].name, "Zoo");
+        assert_eq!(projected[1].name, "Beta");
+        assert_eq!(projected[2].name, "alpha.txt");
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,5 +1,5 @@
 pub mod explorer;
 mod ipc;
 
-pub use explorer::jobs;
+pub use explorer::{jobs, projection};
 pub use ipc::directory;

--- a/crates/platform-windows/src/windows/fs.rs
+++ b/crates/platform-windows/src/windows/fs.rs
@@ -3,9 +3,7 @@ use chrono::{DateTime, Local};
 use file_explorer_core::directory::{
     DirectoryItemKind, DirectoryItemStub, ExplorerError, NativeIconBatchResponse,
     NativeIconRequestItem, NativeIconResult, NativeIconState, SidebarRoot, SidebarRootKind,
-    SortDirection, SortField, SortSpec,
 };
-use std::cmp::Ordering;
 use std::fs;
 use std::os::windows::ffi::OsStrExt;
 use std::os::windows::fs::MetadataExt;
@@ -327,105 +325,6 @@ pub fn hydrate_directory_icons(items: &[NativeIconRequestItem]) -> NativeIconBat
     }
 }
 
-pub fn project_directory_snapshot(
-    items: &[DirectoryItemStub],
-    query: Option<&str>,
-    sort: Option<SortSpec>,
-) -> Vec<DirectoryItemStub> {
-    let normalized_query = normalize_query(query);
-    let mut projected_items = items
-        .iter()
-        .filter(|item| matches_query(item, normalized_query.as_deref()))
-        .cloned()
-        .collect::<Vec<_>>();
-
-    sort_directory_items(&mut projected_items, &sort.unwrap_or(default_sort_spec()));
-    projected_items
-}
-
-fn normalize_query(query: Option<&str>) -> Option<String> {
-    let trimmed_query = query.unwrap_or_default().trim();
-    if trimmed_query.is_empty() {
-        return None;
-    }
-
-    Some(trimmed_query.to_ascii_lowercase())
-}
-
-fn matches_query(item: &DirectoryItemStub, normalized_query: Option<&str>) -> bool {
-    let Some(normalized_query) = normalized_query else {
-        return true;
-    };
-
-    format!(
-        "{} {} {}",
-        item.name,
-        searchable_kind_label(&item.kind),
-        item.path
-    )
-    .to_ascii_lowercase()
-    .contains(normalized_query)
-}
-
-fn sort_directory_items(items: &mut [DirectoryItemStub], sort_spec: &SortSpec) {
-    items.sort_by(|left, right| compare_directory_items(left, right, sort_spec));
-}
-
-fn compare_directory_items(
-    left: &DirectoryItemStub,
-    right: &DirectoryItemStub,
-    sort_spec: &SortSpec,
-) -> Ordering {
-    let left_is_folder_group = matches!(
-        left.kind,
-        DirectoryItemKind::Directory | DirectoryItemKind::Symlink
-    );
-    let right_is_folder_group = matches!(
-        right.kind,
-        DirectoryItemKind::Directory | DirectoryItemKind::Symlink
-    );
-
-    let directory_bias = match (left_is_folder_group, right_is_folder_group) {
-        (true, false) => Ordering::Less,
-        (false, true) => Ordering::Greater,
-        _ => Ordering::Equal,
-    };
-
-    if directory_bias != Ordering::Equal {
-        return directory_bias;
-    }
-
-    let ordering = match sort_spec.field {
-        SortField::Name => left
-            .name
-            .to_ascii_lowercase()
-            .cmp(&right.name.to_ascii_lowercase()),
-        SortField::Type => type_label(&left.kind).cmp(type_label(&right.kind)),
-        SortField::ModifiedAt => left.modified_at.cmp(&right.modified_at),
-        SortField::Size => left.size.cmp(&right.size),
-    };
-
-    let ordering = if ordering == Ordering::Equal {
-        left.name
-            .to_ascii_lowercase()
-            .cmp(&right.name.to_ascii_lowercase())
-    } else {
-        ordering
-    };
-
-    match sort_spec.direction {
-        SortDirection::Asc => ordering,
-        SortDirection::Desc => ordering.reverse(),
-    }
-}
-
-fn default_sort_spec() -> SortSpec {
-    SortSpec {
-        field: SortField::Type,
-        direction: SortDirection::Asc,
-    }
-}
-
 fn parse_rename_target_name(target_name: &str) -> Result<&str, ExplorerError> {
     let trimmed_target_name = target_name.trim();
     if trimmed_target_name.is_empty() {
@@ -706,82 +605,14 @@ fn file_attributes_are_hidden(file_attributes: u32) -> bool {
     file_attributes & FILE_ATTRIBUTE_HIDDEN.0 != 0
 }
 
-fn searchable_kind_label(kind: &DirectoryItemKind) -> &'static str {
-    match kind {
-        DirectoryItemKind::Directory => "directory",
-        DirectoryItemKind::File => "file",
-        DirectoryItemKind::Symlink => "symlink",
-        DirectoryItemKind::Other => "other",
-    }
-}
-
-fn type_label(kind: &DirectoryItemKind) -> &'static str {
-    match kind {
-        DirectoryItemKind::Directory => "Folder",
-        DirectoryItemKind::File => "File",
-        DirectoryItemKind::Symlink => "Shortcut",
-        DirectoryItemKind::Other => "Other",
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    fn item(name: &str, path: &str, kind: DirectoryItemKind) -> DirectoryItemStub {
-        DirectoryItemStub {
-            id: path.to_string(),
-            name: name.to_string(),
-            path: path.to_string(),
-            kind,
-            size: None,
-            modified_at: None,
-            hidden: false,
-            readonly: false,
-            icon_data_url: None,
-            native_icon_state: NativeIconState::Pending,
-        }
-    }
 
     #[test]
     fn has_hidden_attribute_checks_windows_hidden_flag() {
         assert!(file_attributes_are_hidden(FILE_ATTRIBUTE_HIDDEN.0));
         assert!(!file_attributes_are_hidden(0));
-    }
-
-    #[test]
-    fn project_directory_snapshot_filters_without_mutating_source_items() {
-        let items = vec![
-            item("Alpha", r"C:\\Work\\Alpha.txt", DirectoryItemKind::File),
-            item("Beta", r"C:\\Work\\Beta", DirectoryItemKind::Directory),
-        ];
-
-        let projected = project_directory_snapshot(&items, Some("beta"), None);
-
-        assert_eq!(projected, vec![items[1].clone()]);
-        assert_eq!(items.len(), 2);
-    }
-
-    #[test]
-    fn project_directory_snapshot_keeps_directories_grouped_when_sorting_by_name_desc() {
-        let items = vec![
-            item("alpha.txt", r"C:\\Work\\alpha.txt", DirectoryItemKind::File),
-            item("Zoo", r"C:\\Work\\Zoo", DirectoryItemKind::Directory),
-            item("Beta", r"C:\\Work\\Beta", DirectoryItemKind::Directory),
-        ];
-
-        let projected = project_directory_snapshot(
-            &items,
-            None,
-            Some(SortSpec {
-                field: SortField::Name,
-                direction: SortDirection::Desc,
-            }),
-        );
-
-        assert_eq!(projected[0].name, "Zoo");
-        assert_eq!(projected[1].name, "Beta");
-        assert_eq!(projected[2].name, "alpha.txt");
     }
 
     #[test]

--- a/package.json
+++ b/package.json
@@ -4,12 +4,12 @@
   "description": "Windows-first file explorer built with a Rust core and a thin Tauri renderer.",
   "type": "module",
   "scripts": {
-    "dev": "vite dev",
-    "build": "svelte-kit sync && vite build",
-    "preview": "vite preview",
-    "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
-    "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
-    "tauri": "tauri"
+    "dev": "bun node_modules/vite/bin/vite.js dev",
+    "build": "bun node_modules/@sveltejs/kit/svelte-kit.js sync && bun node_modules/vite/bin/vite.js build",
+    "preview": "bun node_modules/vite/bin/vite.js preview",
+    "check": "bun node_modules/@sveltejs/kit/svelte-kit.js sync && bun node_modules/svelte-check/bin/svelte-check --tsconfig ./tsconfig.json",
+    "check:watch": "bun node_modules/@sveltejs/kit/svelte-kit.js sync && bun node_modules/svelte-check/bin/svelte-check --tsconfig ./tsconfig.json --watch",
+    "tauri": "bun node_modules/@tauri-apps/cli/tauri.js"
   },
   "license": "MIT",
   "dependencies": {

--- a/src-tauri/src/explorer/service.rs
+++ b/src-tauri/src/explorer/service.rs
@@ -7,6 +7,7 @@ use file_explorer_core::directory::{
     SidebarRootKind, SnapshotChunk, SnapshotCompleted, SnapshotStarted,
 };
 use file_explorer_core::jobs::{JobHandle, JobRegistry};
+use file_explorer_core::projection;
 use file_explorer_platform_windows::windows::{fs, icons};
 use std::collections::{BTreeSet, HashMap};
 use std::sync::{Arc, Mutex};
@@ -404,7 +405,7 @@ impl ExplorerService {
         }
 
         let project_started_at = Instant::now();
-        let entries = fs::project_directory_snapshot(
+        let entries = projection::project_directory_snapshot(
             resolved_snapshot.items.as_ref(),
             request.query.as_deref(),
             request.sort.clone(),

--- a/src/lib/components/settings/SettingsDialog.svelte
+++ b/src/lib/components/settings/SettingsDialog.svelte
@@ -285,10 +285,8 @@
   }
 
   .feature-row {
-    background:
-      linear-gradient(135deg, color-mix(in srgb, var(--accent-soft) 72%, transparent), transparent 58%),
-      color-mix(in srgb, var(--surface-subtle) 80%, transparent);
-    border-color: color-mix(in srgb, var(--selection-border) 46%, var(--panel-border));
+    background: color-mix(in srgb, var(--surface-subtle) 78%, transparent);
+    border-color: color-mix(in srgb, var(--panel-border) 88%, transparent);
   }
 
   .choice-copy {

--- a/src/lib/components/settings/SettingsDialog.svelte
+++ b/src/lib/components/settings/SettingsDialog.svelte
@@ -4,9 +4,10 @@
   import { settingsUi, type SettingsSection } from "$lib/stores/settingsUi";
 
   let { open, section } = $derived($settingsUi);
-  let { themePreference, artificialNavDelayMs } = $derived($settings);
+  let { themePreference, artificialNavDelayMs, sessionRestoreEnabled } = $derived($settings);
 
   const sections: Array<{ id: SettingsSection; label: string }> = [
+    { id: "general", label: "General" },
     { id: "appearance", label: "Appearance" },
     { id: "developer", label: "Developer" },
     { id: "about", label: "About" }
@@ -20,6 +21,10 @@
 
   function close() {
     settingsUi.closeSettings();
+  }
+
+  function updateSessionRestore(event: Event) {
+    settings.setSessionRestoreEnabled((event.currentTarget as HTMLInputElement).checked);
   }
 </script>
 
@@ -66,7 +71,29 @@
         </nav>
 
         <div class="panel">
-          {#if section === "appearance"}
+          {#if section === "general"}
+            <header class="section-header">
+              <p class="eyebrow">General</p>
+              <h3>Startup</h3>
+            </header>
+
+            <div class="stack">
+              <label class="setting-row choice-row feature-row">
+                <span class="choice-copy">
+                  <strong>Restore previous session</strong>
+                  <small>Reopen tabs, navigation state, and selections on startup.</small>
+                </span>
+                <input
+                  aria-label="Restore previous session"
+                  checked={sessionRestoreEnabled}
+                  class="switch-input"
+                  onchange={updateSessionRestore}
+                  role="switch"
+                  type="checkbox"
+                />
+              </label>
+            </div>
+          {:else if section === "appearance"}
             <header class="section-header">
               <p class="eyebrow">Appearance</p>
               <h3>Theme</h3>
@@ -257,6 +284,13 @@
     background: color-mix(in srgb, var(--surface-subtle) 74%, transparent);
   }
 
+  .feature-row {
+    background:
+      linear-gradient(135deg, color-mix(in srgb, var(--accent-soft) 72%, transparent), transparent 58%),
+      color-mix(in srgb, var(--surface-subtle) 80%, transparent);
+    border-color: color-mix(in srgb, var(--selection-border) 46%, var(--panel-border));
+  }
+
   .choice-copy {
     display: grid;
     gap: 4px;
@@ -292,6 +326,63 @@
     border-radius: 8px;
     background: var(--surface-input);
     color: var(--text-primary);
+  }
+
+  .switch-input {
+    appearance: none;
+    position: relative;
+    flex: 0 0 auto;
+    width: 42px;
+    height: 24px;
+    margin: 0;
+    border: 1px solid color-mix(in srgb, var(--button-border) 84%, var(--text-muted));
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--surface-input) 88%, var(--text-muted) 12%);
+    box-shadow: inset 0 1px 2px rgba(15, 23, 42, 0.12);
+    cursor: pointer;
+    transition:
+      background 160ms ease,
+      border-color 160ms ease,
+      box-shadow 160ms ease;
+  }
+
+  .switch-input::before {
+    content: "";
+    position: absolute;
+    top: 3px;
+    left: 3px;
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    background: var(--text-muted);
+    box-shadow: 0 1px 3px rgba(15, 23, 42, 0.28);
+    transition:
+      transform 160ms ease,
+      background 160ms ease,
+      box-shadow 160ms ease;
+  }
+
+  .switch-input:checked {
+    border-color: color-mix(in srgb, var(--accent-text) 42%, var(--selection-border));
+    background: color-mix(in srgb, var(--accent-soft-strong) 86%, var(--surface-input));
+    box-shadow:
+      inset 0 1px 2px rgba(15, 23, 42, 0.1),
+      0 0 0 1px color-mix(in srgb, var(--accent-text) 12%, transparent);
+  }
+
+  .switch-input:checked::before {
+    transform: translateX(18px);
+    background: var(--accent-text);
+    box-shadow: 0 2px 5px rgba(15, 23, 42, 0.32);
+  }
+
+  .switch-input:focus-visible {
+    outline: 2px solid var(--focus-ring);
+    outline-offset: 2px;
+  }
+
+  .switch-input:hover {
+    border-color: color-mix(in srgb, var(--accent-text) 34%, var(--button-border));
   }
 
   .actions-row {

--- a/src/lib/stores/explorerSessionCore.ts
+++ b/src/lib/stores/explorerSessionCore.ts
@@ -1,15 +1,26 @@
 import { get, writable } from "svelte/store";
 import {
   cancelDirectoryNavigation,
-  createDirectory,
-  deleteToRecycleBin,
-  hydrateDirectoryIcons,
   listSidebarRoots,
   openDirectoryItem,
-  renameDirectoryItem,
   startDirectoryNavigation
 } from "$lib/tauri/explorer";
 import { notify } from "$lib/stores/notifications";
+import {
+  applyDerivedState,
+  classifyOperation,
+  createRenameStateForItem,
+  defaultDirectionForField,
+  delay,
+  ensureRenameItemVisible,
+  getErrorMessage,
+  resolveCompletedOperationType,
+  shouldPreserveVisibleRows,
+  type ExplorerRestoreState
+} from "$lib/stores/explorerSessionHelpers";
+import { createExplorerIconHydration } from "$lib/stores/explorerSessionIcons";
+import { createExplorerMutationActions } from "$lib/stores/explorerSessionMutations";
+import { createExplorerSelectionActions } from "$lib/stores/explorerSessionSelection";
 import {
   completeExplorerTrace,
   markExplorerTraceStage,
@@ -19,14 +30,11 @@ import {
 import { settings } from "$lib/stores/settings";
 import type {
   DirectoryItemStub,
-  DeleteToRecycleBinResponse,
   ExplorerOperationType,
-  ExplorerRenameState,
   ExplorerState,
   ExplorerStreamEvent,
   ExplorerTabId,
   ExplorerTabSnapshot,
-  NativeIconBatchResponse,
   NavigationRequest,
   SortField,
   SortSpec,
@@ -35,6 +43,8 @@ import type {
 import { createJobId } from "$lib/types/explorer";
 
 const DEFAULT_SORT: SortSpec = { field: "type", direction: "asc" };
+
+export { applyDerivedState } from "$lib/stores/explorerSessionHelpers";
 
 export const initialExplorerState: ExplorerState = {
   roots: [],
@@ -68,20 +78,6 @@ type ExplorerSessionInitOptions = {
   snapshot?: Partial<ExplorerTabSnapshot>;
 };
 
-type ExplorerRestoreState = Pick<
-  ExplorerState,
-  | "selectedIds"
-  | "focusedItemId"
-  | "anchorItemId"
-  | "backHistory"
-  | "forwardHistory"
-  | "stagedSearchQuery"
-  | "appliedSearchQuery"
-> & {
-  renameItemId?: string | null;
-  renameFallbackItem?: DirectoryItemStub | null;
-};
-
 export type ExplorerSession = ReturnType<typeof createExplorerSession>;
 
 export function createExplorerSession(tabId: ExplorerTabId) {
@@ -89,10 +85,21 @@ export function createExplorerSession(tabId: ExplorerTabId) {
   let currentChannel: { onmessage: ((message: ExplorerStreamEvent) => void) | null } | null = null;
   let pendingRestore: ExplorerRestoreState | null = null;
   const operationTypes = new Map<string, ExplorerOperationType>();
-  const queuedIconHydrationKinds = new Map<string, DirectoryItemStub["kind"]>();
-  const inflightIconHydrationGenerations = new Map<string, number>();
-  let iconHydrationTimer: ReturnType<typeof setTimeout> | null = null;
-  let iconHydrationGeneration = 0;
+  const setPendingRestore = (restore: ExplorerRestoreState | null) => {
+    pendingRestore = restore;
+  };
+  const iconHydration = createExplorerIconHydration({ store });
+  const mutationActions = createExplorerMutationActions({
+    store,
+    navigate,
+    setPendingRestore
+  });
+  const selectionActions = createExplorerSelectionActions({
+    store,
+    dismissRenameForContextChange: mutationActions.dismissRenameForContextChange,
+    openItem,
+    cancelCurrentJob
+  });
 
   async function initialize(options: ExplorerSessionInitOptions = {}) {
     try {
@@ -165,9 +172,9 @@ export function createExplorerSession(tabId: ExplorerTabId) {
       return;
     }
 
-    dismissRenameForContextChange();
+    mutationActions.dismissRenameForContextChange();
 
-    invalidateIconHydration();
+    iconHydration.invalidateIconHydration();
 
     const beforeNavigate = get(store);
     const preserveVisibleRows = shouldPreserveVisibleRows(beforeNavigate, targetPath);
@@ -345,7 +352,7 @@ export function createExplorerSession(tabId: ExplorerTabId) {
   }
 
   async function openItem(item: DirectoryItemStub) {
-    dismissRenameForContextChange();
+    mutationActions.dismissRenameForContextChange();
 
     if (item.kind === "directory") {
       await navigate(item.path);
@@ -359,77 +366,8 @@ export function createExplorerSession(tabId: ExplorerTabId) {
     }
   }
 
-  async function createNewFolder() {
-    dismissRenameForContextChange();
-
-    const state = get(store);
-    const parentPath = state.currentPath.trim();
-    if (!parentPath) {
-      notify.error("Open a folder before creating a new folder.");
-      return false;
-    }
-
-    if (state.activeJobId) {
-      return false;
-    }
-
-    try {
-      const created = await createDirectory({ parentPath });
-      pendingRestore = createMutationRestoreState(state, [created.path], created.path, createTransientDirectoryItem(created));
-
-      await navigate(parentPath, {
-        skipHistory: true,
-        refreshInPlace: true,
-        forceRefresh: true,
-        restoreSelection: true
-      });
-
-      return true;
-    } catch (error) {
-      notify.error(getErrorMessage(error));
-      return false;
-    }
-  }
-
-  async function deleteItems(items: DirectoryItemStub[]) {
-    dismissRenameForContextChange();
-
-    if (items.length === 0) {
-      return false;
-    }
-
-    const selectedPaths = items.map((item) => item.path);
-
-    try {
-      const result = await deleteToRecycleBin({ targetPaths: selectedPaths });
-      applyDeleteResultState(result);
-      await refreshAfterMutation(result.affectedParentPaths);
-      notifyDeleteResult(result);
-      return result.deleted.length > 0;
-    } catch (error) {
-      notify.error(getErrorMessage(error));
-      return false;
-    }
-  }
-
-  function hydrateVisibleIcons(items: DirectoryItemStub[]) {
-    for (const item of items) {
-      if (item.nativeIconState !== "pending") {
-        continue;
-      }
-
-      if (queuedIconHydrationKinds.has(item.path) || inflightIconHydrationGenerations.has(item.path)) {
-        continue;
-      }
-
-      queuedIconHydrationKinds.set(item.path, item.kind);
-    }
-
-    scheduleIconHydrationFlush();
-  }
-
   async function setSearchQuery(searchQuery: string) {
-    dismissRenameForContextChange();
+    mutationActions.dismissRenameForContextChange();
 
     const stagedSearchQuery = searchQuery;
     const state = get(store);
@@ -448,7 +386,7 @@ export function createExplorerSession(tabId: ExplorerTabId) {
   }
 
   async function setSort(field: SortField) {
-    dismissRenameForContextChange();
+    mutationActions.dismissRenameForContextChange();
 
     const state = get(store);
     const direction = state.sort.field === field
@@ -469,404 +407,12 @@ export function createExplorerSession(tabId: ExplorerTabId) {
     store.update((current) => applyDerivedState({ ...current, sort }));
   }
 
-  function cancelRenameIfEditing() {
-    const renameState = get(store).rename;
-    if (!renameState || renameState.status !== "editing") {
-      return false;
-    }
-
-    store.update((state) => clearTransientRenameFallback(state));
-    return true;
-  }
-
-  function dismissRenameForContextChange() {
-    const renameState = get(store).rename;
-    if (!renameState) {
-      return false;
-    }
-
-    if (renameState.status === "editing") {
-      return cancelRenameIfEditing();
-    }
-
-    store.update((state) => clearTransientRenameFallback(state));
-    return true;
-  }
-
-  function beginRenameSelection() {
-    const state = get(store);
-    if (state.activeJobId || state.selectedIds.length !== 1) {
-      return;
-    }
-
-    const item = state.filteredItems.find((candidate) => candidate.id === state.selectedIds[0]);
-    if (!item) {
-      return;
-    }
-
-    const parentPath = getParentPath(item.path);
-    if (!parentPath) {
-      notify.error(`"${item.name}" cannot be renamed from this location.`);
-      return;
-    }
-
-    store.update((current) => ({
-      ...current,
-      rename: {
-        itemId: item.id,
-        sourcePath: item.path,
-        sourceName: item.name,
-        parentPath,
-        draftName: item.name,
-        status: "editing",
-        error: null
-      }
-    }));
-  }
-
-  function updateRenameDraft(draftName: string) {
-    store.update((state) => {
-      if (!state.rename || state.rename.status !== "editing") {
-        return state;
-      }
-
-      return {
-        ...state,
-        rename: {
-          ...state.rename,
-          draftName,
-          error: null
-        }
-      };
-    });
-  }
-
-  function cancelRename(options: { force?: boolean } = {}) {
-    const state = get(store);
-    if (!state.rename) {
-      return false;
-    }
-
-    if (state.rename.status === "submitting" && !options.force) {
-      return false;
-    }
-
-    store.update((current) => clearTransientRenameFallback(current));
-    return true;
-  }
-
-  async function submitRename() {
-    const renameState = get(store).rename;
-    if (!renameState || renameState.status !== "editing") {
-      return false;
-    }
-
-    const targetName = renameState.draftName.trim();
-    if (!targetName) {
-      store.update((state) => {
-        if (!state.rename || state.rename.itemId !== renameState.itemId) {
-          return state;
-        }
-
-        return {
-          ...state,
-          rename: {
-            ...state.rename,
-            error: "Enter a name before renaming this item."
-          }
-        };
-      });
-      notify.error("Enter a name before renaming this item.");
-      return false;
-    }
-
-    if (targetName === renameState.sourceName) {
-      cancelRename();
-      return true;
-    }
-
-    store.update((state) => {
-      if (!state.rename || state.rename.itemId !== renameState.itemId) {
-        return state;
-      }
-
-      return {
-        ...state,
-        rename: {
-          ...state.rename,
-          draftName: targetName,
-          status: "submitting",
-          error: null
-        }
-      };
-    });
-
-    try {
-      const result = await renameDirectoryItem({
-        sourcePath: renameState.sourcePath,
-        targetName
-      });
-      const state = get(store);
-      const shouldRefreshCurrentFolder = state.currentPath === renameState.parentPath;
-      const restoreState = shouldRefreshCurrentFolder
-        ? createRenameRestoreState(state, renameState.sourcePath, result.path)
-        : null;
-
-      store.update((current) => ({
-        ...current,
-        rename: null
-      }));
-
-      if (shouldRefreshCurrentFolder && restoreState) {
-        pendingRestore = restoreState;
-        await navigate(renameState.parentPath, {
-          skipHistory: true,
-          refreshInPlace: true,
-          forceRefresh: true,
-          restoreSelection: true
-        });
-      }
-
-      notify.success(`Renamed "${renameState.sourceName}" to "${result.name}"`);
-      return true;
-    } catch (error) {
-      const message = getErrorMessage(error);
-      store.update((state) => {
-        if (!state.rename || state.rename.itemId !== renameState.itemId) {
-          return state;
-        }
-
-        return {
-          ...state,
-          rename: {
-            ...state.rename,
-            status: "editing",
-            error: message
-          }
-        };
-      });
-      notify.error(message);
-      return false;
-    }
-  }
-
-  function selectSingle(itemId: string) {
-    dismissRenameForContextChange();
-
-    store.update((state) => ({
-      ...state,
-      selectedIds: [itemId],
-      focusedItemId: itemId,
-      anchorItemId: itemId
-    }));
-  }
-
-  function toggleSelection(itemId: string) {
-    dismissRenameForContextChange();
-
-    store.update((state) => {
-      const nextSelectedIds = state.selectedIds.includes(itemId)
-        ? state.selectedIds.filter((id) => id !== itemId)
-        : [...state.selectedIds, itemId];
-
-      return {
-        ...state,
-        selectedIds: nextSelectedIds,
-        focusedItemId: itemId,
-        anchorItemId: itemId
-      };
-    });
-  }
-
-  function rangeSelectTo(itemId: string) {
-    dismissRenameForContextChange();
-
-    store.update((state) => {
-      const anchorItemId = state.anchorItemId ?? state.focusedItemId;
-      if (!anchorItemId) {
-        return {
-          ...state,
-          selectedIds: [itemId],
-          focusedItemId: itemId,
-          anchorItemId: itemId
-        };
-      }
-
-      const anchorIndex = state.filteredItems.findIndex((item) => item.id === anchorItemId);
-      const targetIndex = state.filteredItems.findIndex((item) => item.id === itemId);
-
-      if (anchorIndex === -1 || targetIndex === -1) {
-        return {
-          ...state,
-          selectedIds: [itemId],
-          focusedItemId: itemId,
-          anchorItemId: itemId
-        };
-      }
-
-      const start = Math.min(anchorIndex, targetIndex);
-      const end = Math.max(anchorIndex, targetIndex);
-
-      return {
-        ...state,
-        selectedIds: state.filteredItems.slice(start, end + 1).map((item) => item.id),
-        focusedItemId: itemId,
-        anchorItemId
-      };
-    });
-  }
-
-  function selectWithModifiers(
-    itemId: string,
-    options: { shiftKey: boolean; ctrlKey: boolean; metaKey: boolean }
-  ) {
-    if (options.shiftKey) {
-      rangeSelectTo(itemId);
-      return;
-    }
-
-    if (options.ctrlKey || options.metaKey) {
-      toggleSelection(itemId);
-      return;
-    }
-
-    selectSingle(itemId);
-  }
-
-  function selectAllVisible() {
-    dismissRenameForContextChange();
-
-    store.update((state) => ({
-      ...state,
-      selectedIds: state.filteredItems.map((item) => item.id),
-      focusedItemId: state.focusedItemId ?? state.filteredItems[0]?.id ?? null,
-      anchorItemId: state.anchorItemId ?? state.filteredItems[0]?.id ?? null
-    }));
-  }
-
-  function clearSelection() {
-    dismissRenameForContextChange();
-
-    store.update((state) => ({
-      ...state,
-      selectedIds: [],
-      focusedItemId: null,
-      anchorItemId: null
-    }));
-  }
-
-  function moveFocus(delta: number) {
-    dismissRenameForContextChange();
-
-    const state = get(store);
-    if (state.filteredItems.length === 0) {
-      return;
-    }
-
-    const currentIndex = state.filteredItems.findIndex((item) => item.id === state.focusedItemId);
-    const nextIndex = currentIndex === -1
-      ? delta < 0
-        ? state.filteredItems.length - 1
-        : 0
-      : Math.max(0, Math.min(state.filteredItems.length - 1, currentIndex + delta));
-    const target = state.filteredItems[nextIndex];
-
-    if (target) {
-      selectSingle(target.id);
-    }
-  }
-
-  function focusFirst() {
-    dismissRenameForContextChange();
-
-    const first = get(store).filteredItems[0];
-    if (first) {
-      selectSingle(first.id);
-    }
-  }
-
-  function focusLast() {
-    dismissRenameForContextChange();
-
-    const last = get(store).filteredItems.at(-1);
-    if (last) {
-      selectSingle(last.id);
-    }
-  }
-
-  async function openFocused() {
-    const state = get(store);
-    const target = state.filteredItems.find((item) => item.id === state.focusedItemId)
-      ?? state.filteredItems.find((item) => item.id === state.selectedIds[0]);
-
-    if (target) {
-      await openItem(target);
-    }
-  }
-
-  async function cancelActiveNavigation() {
-    const activeJobId = get(store).activeJobId;
-    if (activeJobId) {
-      await cancelCurrentJob(activeJobId);
-    }
-  }
-
-  async function refreshAfterMutation(affectedParentPaths: string[]) {
-    const { currentPath } = get(store);
-    if (!currentPath || !affectedParentPaths.some((path) => isSameExplorerPath(path, currentPath))) {
-      store.update((state) => applyDerivedState({
-        ...state,
-        selectedIds: [],
-        focusedItemId: null,
-        anchorItemId: null
-      }));
-      return;
-    }
-
-    await navigate(currentPath, {
-      skipHistory: true,
-      refreshInPlace: true,
-      forceRefresh: true,
-      restoreSelection: true
-    });
-  }
-
-  function applyDeleteResultState(result: DeleteToRecycleBinResponse) {
-    const deletedIdSet = new Set(result.deleted.map((item) => item.path));
-    if (deletedIdSet.size === 0) {
-      return;
-    }
-
-    store.update((state) => applyDerivedState({
-      ...state,
-      selectedIds: state.selectedIds.filter((itemId) => !deletedIdSet.has(itemId)),
-      focusedItemId: deletedIdSet.has(state.focusedItemId ?? "") ? null : state.focusedItemId,
-      anchorItemId: deletedIdSet.has(state.anchorItemId ?? "") ? null : state.anchorItemId
-    }));
-  }
-
-  function notifyDeleteResult(result: DeleteToRecycleBinResponse) {
-    if (result.deleted.length > 0 && result.failed.length === 0) {
-      notify.success(formatDeleteSuccessMessage(result.deleted.length));
-      return;
-    }
-
-    if (result.deleted.length > 0) {
-      notify.warning(
-        `${formatDeleteSuccessMessage(result.deleted.length)} ${formatDeleteFailureSummary(result.failed)}`
-      );
-      return;
-    }
-
-    notify.error(formatDeleteFailureSummary(result.failed));
-  }
-
   function dispose() {
     const activeJobId = get(store).activeJobId;
     if (activeJobId) {
       void cancelCurrentJob(activeJobId);
     }
-    invalidateIconHydration();
+    iconHydration.invalidateIconHydration();
     currentChannel = null;
     pendingRestore = null;
   }
@@ -896,7 +442,7 @@ export function createExplorerSession(tabId: ExplorerTabId) {
 
     switch (event.event) {
       case "snapshotStarted":
-        invalidateIconHydration();
+        iconHydration.invalidateIconHydration();
         store.update((state) =>
           applyDerivedState({
             ...state,
@@ -931,7 +477,7 @@ export function createExplorerSession(tabId: ExplorerTabId) {
         break;
       case "snapshotCompleted":
         updateExplorerTraceOperation(event.data.jobId, resolveCompletedOperationType(operationTypes.get(event.data.jobId), event.data.cacheHit));
-        iconHydrationGeneration += 1;
+        iconHydration.markSnapshotCommitted();
         store.update((state) => {
           const completed = state.isRefreshing
             ? applyDerivedState({
@@ -1067,116 +613,6 @@ export function createExplorerSession(tabId: ExplorerTabId) {
     }
   }
 
-  function scheduleIconHydrationFlush() {
-    if (iconHydrationTimer || queuedIconHydrationKinds.size === 0) {
-      return;
-    }
-
-    iconHydrationTimer = setTimeout(() => {
-      iconHydrationTimer = null;
-      void flushIconHydrationQueue();
-    }, 0);
-  }
-
-  async function flushIconHydrationQueue() {
-    if (queuedIconHydrationKinds.size === 0) {
-      return;
-    }
-
-    const requestGeneration = iconHydrationGeneration;
-    const requestItems = [...queuedIconHydrationKinds.entries()].map(([path, kind]) => ({ path, kind }));
-    queuedIconHydrationKinds.clear();
-
-    for (const item of requestItems) {
-      inflightIconHydrationGenerations.set(item.path, requestGeneration);
-    }
-
-    markItemsLoading(requestItems.map((item) => item.path), requestGeneration);
-
-    try {
-      const response = await hydrateDirectoryIcons({ items: requestItems });
-      if (requestGeneration !== iconHydrationGeneration) {
-        return;
-      }
-
-      store.update((state) =>
-        applyDerivedState({
-          ...state,
-          items: mergeHydratedIcons(state.items, response.items),
-          pendingItems: mergeHydratedIcons(state.pendingItems, response.items)
-        })
-      );
-    } catch {
-      markItemsFailed(requestItems.map((item) => item.path), requestGeneration);
-    } finally {
-      for (const item of requestItems) {
-        if (inflightIconHydrationGenerations.get(item.path) === requestGeneration) {
-          inflightIconHydrationGenerations.delete(item.path);
-        }
-      }
-    }
-  }
-
-  function invalidateIconHydration() {
-    iconHydrationGeneration += 1;
-    clearQueuedIconHydration();
-    inflightIconHydrationGenerations.clear();
-    store.update((state) =>
-      applyDerivedState({
-        ...state,
-        items: resetObsoleteLoadingIconState(state.items),
-        pendingItems: resetObsoleteLoadingIconState(state.pendingItems)
-      })
-    );
-  }
-
-  function clearQueuedIconHydration() {
-    if (iconHydrationTimer) {
-      clearTimeout(iconHydrationTimer);
-      iconHydrationTimer = null;
-    }
-
-    queuedIconHydrationKinds.clear();
-  }
-
-  function markItemsLoading(paths: string[], requestGeneration: number) {
-    if (requestGeneration !== iconHydrationGeneration) {
-      return;
-    }
-
-    if (paths.length === 0) {
-      return;
-    }
-
-    const pathSet = new Set(paths);
-    store.update((state) =>
-      applyDerivedState({
-        ...state,
-        items: updateNativeIconState(state.items, pathSet, "loading"),
-        pendingItems: updateNativeIconState(state.pendingItems, pathSet, "loading")
-      })
-    );
-  }
-
-  function markItemsFailed(paths: string[], requestGeneration: number) {
-    if (requestGeneration !== iconHydrationGeneration) {
-      return;
-    }
-
-    if (paths.length === 0) {
-      return;
-    }
-
-    const pathSet = new Set(paths);
-    store.update((state) =>
-      applyDerivedState({
-        ...state,
-        items: updateNativeIconState(state.items, pathSet, "failed"),
-        pendingItems: updateNativeIconState(state.pendingItems, pathSet, "failed")
-      })
-    );
-  }
-
   return {
     subscribe: store.subscribe,
     initialize,
@@ -1188,462 +624,27 @@ export function createExplorerSession(tabId: ExplorerTabId) {
     goUp,
     openRoot,
     openItem,
-    createNewFolder,
-    deleteItems,
-    hydrateVisibleIcons,
+    createNewFolder: mutationActions.createNewFolder,
+    deleteItems: mutationActions.deleteItems,
+    hydrateVisibleIcons: iconHydration.hydrateVisibleIcons,
     setSearchQuery,
     setSort,
-    beginRenameSelection,
-    updateRenameDraft,
-    submitRename,
-    cancelRename,
-    selectSingle,
-    toggleSelection,
-    rangeSelectTo,
-    selectWithModifiers,
-    selectAllVisible,
-    clearSelection,
-    moveFocus,
-    focusFirst,
-    focusLast,
-    openFocused,
-    cancelActiveNavigation,
+    beginRenameSelection: mutationActions.beginRenameSelection,
+    updateRenameDraft: mutationActions.updateRenameDraft,
+    submitRename: mutationActions.submitRename,
+    cancelRename: mutationActions.cancelRename,
+    selectSingle: selectionActions.selectSingle,
+    toggleSelection: selectionActions.toggleSelection,
+    rangeSelectTo: selectionActions.rangeSelectTo,
+    selectWithModifiers: selectionActions.selectWithModifiers,
+    selectAllVisible: selectionActions.selectAllVisible,
+    clearSelection: selectionActions.clearSelection,
+    moveFocus: selectionActions.moveFocus,
+    focusFirst: selectionActions.focusFirst,
+    focusLast: selectionActions.focusLast,
+    openFocused: selectionActions.openFocused,
+    cancelActiveNavigation: selectionActions.cancelActiveNavigation,
     createSnapshot,
     dispose
   };
-}
-
-export function applyDerivedState(state: ExplorerState): ExplorerState {
-  const filteredItems = state.items;
-  const selectedIds = state.selectedIds.filter((id) => filteredItems.some((item) => item.id === id));
-  const focusedItemId = filteredItems.some((item) => item.id === state.focusedItemId)
-    ? state.focusedItemId
-    : null;
-  const anchorItemId = filteredItems.some((item) => item.id === state.anchorItemId)
-    ? state.anchorItemId
-    : focusedItemId;
-
-  return {
-    ...state,
-    filteredItems,
-    pendingItems: state.pendingItems,
-    selectedIds,
-    focusedItemId,
-    anchorItemId
-  };
-}
-
-function getErrorMessage(error: unknown) {
-  if (typeof error === "string") {
-    return error;
-  }
-
-  if (error && typeof error === "object" && "message" in error) {
-    return String(error.message);
-  }
-
-  return "An unexpected explorer error occurred.";
-}
-
-function defaultDirectionForField(field: SortField): SortSpec["direction"] {
-  switch (field) {
-    case "modifiedAt":
-    case "size":
-      return "desc";
-    case "name":
-    case "type":
-    default:
-      return "asc";
-  }
-}
-
-function classifyOperation(
-  state: ExplorerState,
-  targetPath: string,
-  request: NavigationRequest,
-  options: {
-    refreshInPlace?: boolean;
-    forceRefresh?: boolean;
-  }
-): ExplorerOperationType {
-  if (options.forceRefresh) {
-    return "refresh";
-  }
-
-  const nextQuery = request.query ?? "";
-  if (nextQuery !== state.appliedSearchQuery) {
-    return "search";
-  }
-
-  const nextSort = request.sort ?? state.sort;
-  if (nextSort.field !== state.sort.field || nextSort.direction !== state.sort.direction) {
-    return "sort";
-  }
-
-  if (targetPath !== state.currentPath) {
-    return state.items.length > 0 ? "warm_navigation" : "cold_navigation";
-  }
-
-  return options.refreshInPlace ? "warm_navigation" : "cold_navigation";
-}
-
-function shouldPreserveVisibleRows(state: ExplorerState, targetPath: string) {
-  return state.currentPath === targetPath && state.items.length > 0;
-}
-
-function resolveCompletedOperationType(
-  requestedOperationType: ExplorerOperationType | undefined,
-  cacheHit: boolean
-): ExplorerOperationType {
-  if (requestedOperationType === "search" || requestedOperationType === "sort" || requestedOperationType === "refresh") {
-    return requestedOperationType;
-  }
-
-  return cacheHit ? "warm_navigation" : "cold_navigation";
-}
-
-function createRenameRestoreState(
-  state: ExplorerState,
-  sourcePath: string,
-  renamedPath: string
-): ExplorerRestoreState {
-  return {
-    selectedIds: state.selectedIds.map((itemId) => itemId === sourcePath ? renamedPath : itemId),
-    focusedItemId: state.focusedItemId === sourcePath ? renamedPath : state.focusedItemId,
-    anchorItemId: state.anchorItemId === sourcePath ? renamedPath : state.anchorItemId,
-    backHistory: [...state.backHistory],
-    forwardHistory: [...state.forwardHistory],
-    stagedSearchQuery: state.stagedSearchQuery,
-    appliedSearchQuery: state.appliedSearchQuery,
-    renameItemId: null
-  };
-}
-
-function createMutationRestoreState(
-  state: ExplorerState,
-  selectedIds: string[],
-  renameItemId: string | null = null,
-  renameFallbackItem: DirectoryItemStub | null = null
-): ExplorerRestoreState {
-  return {
-    selectedIds: [...selectedIds],
-    focusedItemId: selectedIds[0] ?? null,
-    anchorItemId: selectedIds[0] ?? null,
-    backHistory: [...state.backHistory],
-    forwardHistory: [...state.forwardHistory],
-    stagedSearchQuery: state.stagedSearchQuery,
-    appliedSearchQuery: state.appliedSearchQuery,
-    renameItemId,
-    renameFallbackItem
-  };
-}
-
-function createRenameStateForItem(state: ExplorerState, itemId: string): NonNullable<ExplorerRenameState> | null {
-  const item = state.filteredItems.find((candidate) => candidate.id === itemId);
-  if (!item) {
-    notify.error("The created folder could not be found after refresh.");
-    return null;
-  }
-
-  const parentPath = getParentPath(item.path);
-  if (!parentPath) {
-    notify.error(`"${item.name}" cannot be renamed from this location.`);
-    return null;
-  }
-
-  return {
-    itemId: item.id,
-    sourcePath: item.path,
-    sourceName: item.name,
-    parentPath,
-    draftName: item.name,
-    status: "editing",
-    error: null
-  };
-}
-
-function ensureRenameItemVisible(
-  state: ExplorerState,
-  itemId: string,
-  fallbackItem: DirectoryItemStub | null | undefined
-) {
-  if (state.filteredItems.some((candidate) => candidate.id === itemId) || !fallbackItem) {
-    return state;
-  }
-
-  return applyDerivedState({
-    ...state,
-    items: insertVisibleRenameFallback(state.items, fallbackItem, state.sort)
-  });
-}
-
-function insertVisibleRenameFallback(items: DirectoryItemStub[], fallbackItem: DirectoryItemStub, sort: SortSpec) {
-  if (items.some((item) => item.id === fallbackItem.id)) {
-    return items;
-  }
-
-  const nextItems = [...items, fallbackItem];
-  return sortDirectoryItems(nextItems, sort);
-}
-
-function createTransientDirectoryItem(created: { path: string; name: string; parentPath: string }): DirectoryItemStub {
-  return {
-    id: created.path,
-    path: created.path,
-    name: created.name,
-    kind: "directory",
-    hidden: false,
-    readonly: false,
-    nativeIconState: "pending"
-  };
-}
-
-function clearTransientRenameFallback(state: ExplorerState) {
-  const renameState = state.rename;
-  if (!renameState) {
-    return state;
-  }
-
-  const renamedItem = state.items.find((item) => item.id === renameState.itemId);
-
-  const nextState = {
-    ...state,
-    rename: null
-  } satisfies ExplorerState;
-  if (!renamedItem || matchesExplorerQuery(renamedItem, state.appliedSearchQuery)) {
-    return nextState;
-  }
-
-  return applyDerivedState({
-    ...nextState,
-    items: nextState.items.filter((item) => item.id !== renameState.itemId)
-  });
-}
-
-function formatDeleteSuccessMessage(count: number) {
-  return count === 1 ? "Moved 1 item to the Recycle Bin." : `Moved ${count} items to the Recycle Bin.`;
-}
-
-function formatDeleteFailureSummary(failures: DeleteToRecycleBinResponse["failed"]) {
-  if (failures.length === 0) {
-    return "Delete failed.";
-  }
-
-  if (failures.length === 1) {
-    return failures[0].message;
-  }
-
-  return `${failures.length} items could not be moved to the Recycle Bin. ${failures[0].message}`;
-}
-
-function getParentPath(path: string) {
-  const normalizedPath = path.replace(/[\\/]+$/, "");
-  const separatorIndex = Math.max(normalizedPath.lastIndexOf("\\"), normalizedPath.lastIndexOf("/"));
-  if (separatorIndex === -1) {
-    return null;
-  }
-
-  if (separatorIndex === 2 && normalizedPath[1] === ":") {
-    return normalizedPath.slice(0, separatorIndex + 1);
-  }
-
-  if (separatorIndex === 0) {
-    return normalizedPath.slice(0, 1);
-  }
-
-  return normalizedPath.slice(0, separatorIndex);
-}
-
-function sortDirectoryItems(items: DirectoryItemStub[], sort: SortSpec) {
-  return [...items].sort((left, right) => compareDirectoryItems(left, right, sort));
-}
-
-function compareDirectoryItems(left: DirectoryItemStub, right: DirectoryItemStub, sort: SortSpec) {
-  const directoryBias = compareDirectoryBias(left.kind, right.kind);
-  if (directoryBias !== 0) {
-    return directoryBias;
-  }
-
-  const ordering = compareSortValue(left, right, sort.field);
-  if (ordering !== 0) {
-    return sort.direction === "asc" ? ordering : -ordering;
-  }
-
-  return compareText(left.name, right.name);
-}
-
-function compareDirectoryBias(leftKind: DirectoryItemStub["kind"], rightKind: DirectoryItemStub["kind"]) {
-  const leftIsFolderGroup = leftKind === "directory" || leftKind === "symlink";
-  const rightIsFolderGroup = rightKind === "directory" || rightKind === "symlink";
-
-  if (leftIsFolderGroup && !rightIsFolderGroup) {
-    return -1;
-  }
-
-  if (!leftIsFolderGroup && rightIsFolderGroup) {
-    return 1;
-  }
-
-  return 0;
-}
-
-function compareSortValue(left: DirectoryItemStub, right: DirectoryItemStub, field: SortField) {
-  switch (field) {
-    case "name":
-      return compareText(left.name, right.name);
-    case "type":
-      return compareText(typeLabel(left.kind), typeLabel(right.kind));
-    case "modifiedAt":
-      return compareNullableText(left.modifiedAt, right.modifiedAt);
-    case "size":
-      return compareNullableNumber(left.size, right.size);
-    default:
-      return 0;
-  }
-}
-
-function compareText(left: string, right: string) {
-  if (left.toLowerCase() < right.toLowerCase()) {
-    return -1;
-  }
-
-  if (left.toLowerCase() > right.toLowerCase()) {
-    return 1;
-  }
-
-  return 0;
-}
-
-function compareNullableText(left?: string, right?: string) {
-  const safeLeft = left ?? "";
-  const safeRight = right ?? "";
-  return compareText(safeLeft, safeRight);
-}
-
-function compareNullableNumber(left?: number, right?: number) {
-  const safeLeft = left ?? -1;
-  const safeRight = right ?? -1;
-  if (safeLeft < safeRight) {
-    return -1;
-  }
-
-  if (safeLeft > safeRight) {
-    return 1;
-  }
-
-  return 0;
-}
-
-function typeLabel(kind: DirectoryItemStub["kind"]) {
-  switch (kind) {
-    case "directory":
-      return "Folder";
-    case "file":
-      return "File";
-    case "symlink":
-      return "Shortcut";
-    default:
-      return "Other";
-  }
-}
-
-function matchesExplorerQuery(item: DirectoryItemStub, query: string) {
-  const normalizedQuery = query.trim().toLowerCase();
-  if (!normalizedQuery) {
-    return true;
-  }
-
-  return `${item.name} ${searchableKindLabel(item.kind)} ${item.path}`.toLowerCase().includes(normalizedQuery);
-}
-
-function searchableKindLabel(kind: DirectoryItemStub["kind"]) {
-  switch (kind) {
-    case "directory":
-      return "directory";
-    case "file":
-      return "file";
-    case "symlink":
-      return "symlink";
-    default:
-      return "other";
-  }
-}
-
-function isSameExplorerPath(left: string, right: string) {
-  return normalizeExplorerPath(left) === normalizeExplorerPath(right);
-}
-
-function normalizeExplorerPath(path: string) {
-  return path.trim().replace(/[\\/]+$/, "").toLowerCase();
-}
-
-function delay(durationMs: number) {
-  return new Promise<void>((resolve) => {
-    setTimeout(resolve, durationMs);
-  });
-}
-
-function mergeHydratedIcons(items: DirectoryItemStub[], response: NativeIconBatchResponse["items"]) {
-  if (response.length === 0) {
-    return items;
-  }
-
-  const hydratedByPath = new Map(response.map((item) => [item.path, item]));
-  let changed = false;
-
-  const nextItems = items.map((item) => {
-    const hydrated = hydratedByPath.get(item.path);
-    if (!hydrated) {
-      return item;
-    }
-
-    changed = true;
-    return {
-      ...item,
-      iconDataUrl: hydrated.iconDataUrl,
-      nativeIconState: hydrated.nativeIconState
-    };
-  });
-
-  return changed ? nextItems : items;
-}
-
-function updateNativeIconState(
-  items: DirectoryItemStub[],
-  paths: Set<string>,
-  nextState: DirectoryItemStub["nativeIconState"]
-) {
-  let changed = false;
-
-  const nextItems = items.map((item) => {
-    if (!paths.has(item.path) || item.nativeIconState === nextState || item.nativeIconState === "ready") {
-      return item;
-    }
-
-    changed = true;
-    return {
-      ...item,
-      nativeIconState: nextState
-    };
-  });
-
-  return changed ? nextItems : items;
-}
-
-function resetObsoleteLoadingIconState(items: DirectoryItemStub[]) {
-  let changed = false;
-
-  const nextItems = items.map((item) => {
-    if (item.nativeIconState !== "loading") {
-      return item;
-    }
-
-    changed = true;
-    return {
-      ...item,
-      nativeIconState: "pending" as const
-    };
-  });
-
-  return changed ? nextItems : items;
 }

--- a/src/lib/stores/explorerSessionHelpers.ts
+++ b/src/lib/stores/explorerSessionHelpers.ts
@@ -1,0 +1,461 @@
+import { notify } from "$lib/stores/notifications";
+import type {
+  DeleteToRecycleBinResponse,
+  DirectoryItemStub,
+  ExplorerOperationType,
+  ExplorerRenameState,
+  ExplorerState,
+  NavigationRequest,
+  NativeIconBatchResponse,
+  SortField,
+  SortSpec
+} from "$lib/types/explorer";
+
+export type ExplorerRestoreState = Pick<
+  ExplorerState,
+  | "selectedIds"
+  | "focusedItemId"
+  | "anchorItemId"
+  | "backHistory"
+  | "forwardHistory"
+  | "stagedSearchQuery"
+  | "appliedSearchQuery"
+> & {
+  renameItemId?: string | null;
+  renameFallbackItem?: DirectoryItemStub | null;
+};
+
+export function applyDerivedState(state: ExplorerState): ExplorerState {
+  const filteredItems = state.items;
+  const selectedIds = state.selectedIds.filter((id) => filteredItems.some((item) => item.id === id));
+  const focusedItemId = filteredItems.some((item) => item.id === state.focusedItemId)
+    ? state.focusedItemId
+    : null;
+  const anchorItemId = filteredItems.some((item) => item.id === state.anchorItemId)
+    ? state.anchorItemId
+    : focusedItemId;
+
+  return {
+    ...state,
+    filteredItems,
+    pendingItems: state.pendingItems,
+    selectedIds,
+    focusedItemId,
+    anchorItemId
+  };
+}
+
+export function getErrorMessage(error: unknown) {
+  if (typeof error === "string") {
+    return error;
+  }
+
+  if (error && typeof error === "object" && "message" in error) {
+    return String(error.message);
+  }
+
+  return "An unexpected explorer error occurred.";
+}
+
+export function defaultDirectionForField(field: SortField): SortSpec["direction"] {
+  switch (field) {
+    case "modifiedAt":
+    case "size":
+      return "desc";
+    case "name":
+    case "type":
+    default:
+      return "asc";
+  }
+}
+
+export function classifyOperation(
+  state: ExplorerState,
+  targetPath: string,
+  request: NavigationRequest,
+  options: {
+    refreshInPlace?: boolean;
+    forceRefresh?: boolean;
+  }
+): ExplorerOperationType {
+  if (options.forceRefresh) {
+    return "refresh";
+  }
+
+  const nextQuery = request.query ?? "";
+  if (nextQuery !== state.appliedSearchQuery) {
+    return "search";
+  }
+
+  const nextSort = request.sort ?? state.sort;
+  if (nextSort.field !== state.sort.field || nextSort.direction !== state.sort.direction) {
+    return "sort";
+  }
+
+  if (targetPath !== state.currentPath) {
+    return state.items.length > 0 ? "warm_navigation" : "cold_navigation";
+  }
+
+  return options.refreshInPlace ? "warm_navigation" : "cold_navigation";
+}
+
+export function shouldPreserveVisibleRows(state: ExplorerState, targetPath: string) {
+  return state.currentPath === targetPath && state.items.length > 0;
+}
+
+export function resolveCompletedOperationType(
+  requestedOperationType: ExplorerOperationType | undefined,
+  cacheHit: boolean
+): ExplorerOperationType {
+  if (requestedOperationType === "search" || requestedOperationType === "sort" || requestedOperationType === "refresh") {
+    return requestedOperationType;
+  }
+
+  return cacheHit ? "warm_navigation" : "cold_navigation";
+}
+
+export function createRenameRestoreState(
+  state: ExplorerState,
+  sourcePath: string,
+  renamedPath: string
+): ExplorerRestoreState {
+  return {
+    selectedIds: state.selectedIds.map((itemId) => itemId === sourcePath ? renamedPath : itemId),
+    focusedItemId: state.focusedItemId === sourcePath ? renamedPath : state.focusedItemId,
+    anchorItemId: state.anchorItemId === sourcePath ? renamedPath : state.anchorItemId,
+    backHistory: [...state.backHistory],
+    forwardHistory: [...state.forwardHistory],
+    stagedSearchQuery: state.stagedSearchQuery,
+    appliedSearchQuery: state.appliedSearchQuery,
+    renameItemId: null
+  };
+}
+
+export function createMutationRestoreState(
+  state: ExplorerState,
+  selectedIds: string[],
+  renameItemId: string | null = null,
+  renameFallbackItem: DirectoryItemStub | null = null
+): ExplorerRestoreState {
+  return {
+    selectedIds: [...selectedIds],
+    focusedItemId: selectedIds[0] ?? null,
+    anchorItemId: selectedIds[0] ?? null,
+    backHistory: [...state.backHistory],
+    forwardHistory: [...state.forwardHistory],
+    stagedSearchQuery: state.stagedSearchQuery,
+    appliedSearchQuery: state.appliedSearchQuery,
+    renameItemId,
+    renameFallbackItem
+  };
+}
+
+export function createRenameStateForItem(state: ExplorerState, itemId: string): NonNullable<ExplorerRenameState> | null {
+  const item = state.filteredItems.find((candidate) => candidate.id === itemId);
+  if (!item) {
+    notify.error("The created folder could not be found after refresh.");
+    return null;
+  }
+
+  const parentPath = getParentPath(item.path);
+  if (!parentPath) {
+    notify.error(`"${item.name}" cannot be renamed from this location.`);
+    return null;
+  }
+
+  return {
+    itemId: item.id,
+    sourcePath: item.path,
+    sourceName: item.name,
+    parentPath,
+    draftName: item.name,
+    status: "editing",
+    error: null
+  };
+}
+
+export function ensureRenameItemVisible(
+  state: ExplorerState,
+  itemId: string,
+  fallbackItem: DirectoryItemStub | null | undefined
+) {
+  if (state.filteredItems.some((candidate) => candidate.id === itemId) || !fallbackItem) {
+    return state;
+  }
+
+  return applyDerivedState({
+    ...state,
+    items: insertVisibleRenameFallback(state.items, fallbackItem, state.sort)
+  });
+}
+
+export function createTransientDirectoryItem(created: { path: string; name: string; parentPath: string }): DirectoryItemStub {
+  return {
+    id: created.path,
+    path: created.path,
+    name: created.name,
+    kind: "directory",
+    hidden: false,
+    readonly: false,
+    nativeIconState: "pending"
+  };
+}
+
+export function clearTransientRenameFallback(state: ExplorerState) {
+  const renameState = state.rename;
+  if (!renameState) {
+    return state;
+  }
+
+  const renamedItem = state.items.find((item) => item.id === renameState.itemId);
+
+  const nextState = {
+    ...state,
+    rename: null
+  } satisfies ExplorerState;
+  if (!renamedItem || matchesExplorerQuery(renamedItem, state.appliedSearchQuery)) {
+    return nextState;
+  }
+
+  return applyDerivedState({
+    ...nextState,
+    items: nextState.items.filter((item) => item.id !== renameState.itemId)
+  });
+}
+
+export function formatDeleteSuccessMessage(count: number) {
+  return count === 1 ? "Moved 1 item to the Recycle Bin." : `Moved ${count} items to the Recycle Bin.`;
+}
+
+export function formatDeleteFailureSummary(failures: DeleteToRecycleBinResponse["failed"]) {
+  if (failures.length === 0) {
+    return "Delete failed.";
+  }
+
+  if (failures.length === 1) {
+    return failures[0].message;
+  }
+
+  return `${failures.length} items could not be moved to the Recycle Bin. ${failures[0].message}`;
+}
+
+export function getParentPath(path: string) {
+  const normalizedPath = path.replace(/[\\/]+$/, "");
+  const separatorIndex = Math.max(normalizedPath.lastIndexOf("\\"), normalizedPath.lastIndexOf("/"));
+  if (separatorIndex === -1) {
+    return null;
+  }
+
+  if (separatorIndex === 2 && normalizedPath[1] === ":") {
+    return normalizedPath.slice(0, separatorIndex + 1);
+  }
+
+  if (separatorIndex === 0) {
+    return normalizedPath.slice(0, 1);
+  }
+
+  return normalizedPath.slice(0, separatorIndex);
+}
+
+export function isSameExplorerPath(left: string, right: string) {
+  return normalizeExplorerPath(left) === normalizeExplorerPath(right);
+}
+
+export function delay(durationMs: number) {
+  return new Promise<void>((resolve) => {
+    setTimeout(resolve, durationMs);
+  });
+}
+
+export function mergeHydratedIcons(items: DirectoryItemStub[], response: NativeIconBatchResponse["items"]) {
+  if (response.length === 0) {
+    return items;
+  }
+
+  const hydratedByPath = new Map(response.map((item) => [item.path, item]));
+  let changed = false;
+
+  const nextItems = items.map((item) => {
+    const hydrated = hydratedByPath.get(item.path);
+    if (!hydrated) {
+      return item;
+    }
+
+    changed = true;
+    return {
+      ...item,
+      iconDataUrl: hydrated.iconDataUrl,
+      nativeIconState: hydrated.nativeIconState
+    };
+  });
+
+  return changed ? nextItems : items;
+}
+
+export function updateNativeIconState(
+  items: DirectoryItemStub[],
+  paths: Set<string>,
+  nextState: DirectoryItemStub["nativeIconState"]
+) {
+  let changed = false;
+
+  const nextItems = items.map((item) => {
+    if (!paths.has(item.path) || item.nativeIconState === nextState || item.nativeIconState === "ready") {
+      return item;
+    }
+
+    changed = true;
+    return {
+      ...item,
+      nativeIconState: nextState
+    };
+  });
+
+  return changed ? nextItems : items;
+}
+
+export function resetObsoleteLoadingIconState(items: DirectoryItemStub[]) {
+  let changed = false;
+
+  const nextItems = items.map((item) => {
+    if (item.nativeIconState !== "loading") {
+      return item;
+    }
+
+    changed = true;
+    return {
+      ...item,
+      nativeIconState: "pending" as const
+    };
+  });
+
+  return changed ? nextItems : items;
+}
+
+function insertVisibleRenameFallback(items: DirectoryItemStub[], fallbackItem: DirectoryItemStub, sort: SortSpec) {
+  if (items.some((item) => item.id === fallbackItem.id)) {
+    return items;
+  }
+
+  const nextItems = [...items, fallbackItem];
+  return sortDirectoryItems(nextItems, sort);
+}
+
+function sortDirectoryItems(items: DirectoryItemStub[], sort: SortSpec) {
+  return [...items].sort((left, right) => compareDirectoryItems(left, right, sort));
+}
+
+function compareDirectoryItems(left: DirectoryItemStub, right: DirectoryItemStub, sort: SortSpec) {
+  const directoryBias = compareDirectoryBias(left.kind, right.kind);
+  if (directoryBias !== 0) {
+    return directoryBias;
+  }
+
+  const ordering = compareSortValue(left, right, sort.field);
+  if (ordering !== 0) {
+    return sort.direction === "asc" ? ordering : -ordering;
+  }
+
+  return compareText(left.name, right.name);
+}
+
+function compareDirectoryBias(leftKind: DirectoryItemStub["kind"], rightKind: DirectoryItemStub["kind"]) {
+  const leftIsFolderGroup = leftKind === "directory" || leftKind === "symlink";
+  const rightIsFolderGroup = rightKind === "directory" || rightKind === "symlink";
+
+  if (leftIsFolderGroup && !rightIsFolderGroup) {
+    return -1;
+  }
+
+  if (!leftIsFolderGroup && rightIsFolderGroup) {
+    return 1;
+  }
+
+  return 0;
+}
+
+function compareSortValue(left: DirectoryItemStub, right: DirectoryItemStub, field: SortField) {
+  switch (field) {
+    case "name":
+      return compareText(left.name, right.name);
+    case "type":
+      return compareText(typeLabel(left.kind), typeLabel(right.kind));
+    case "modifiedAt":
+      return compareNullableText(left.modifiedAt, right.modifiedAt);
+    case "size":
+      return compareNullableNumber(left.size, right.size);
+    default:
+      return 0;
+  }
+}
+
+function compareText(left: string, right: string) {
+  if (left.toLowerCase() < right.toLowerCase()) {
+    return -1;
+  }
+
+  if (left.toLowerCase() > right.toLowerCase()) {
+    return 1;
+  }
+
+  return 0;
+}
+
+function compareNullableText(left?: string, right?: string) {
+  const safeLeft = left ?? "";
+  const safeRight = right ?? "";
+  return compareText(safeLeft, safeRight);
+}
+
+function compareNullableNumber(left?: number, right?: number) {
+  const safeLeft = left ?? -1;
+  const safeRight = right ?? -1;
+  if (safeLeft < safeRight) {
+    return -1;
+  }
+
+  if (safeLeft > safeRight) {
+    return 1;
+  }
+
+  return 0;
+}
+
+function typeLabel(kind: DirectoryItemStub["kind"]) {
+  switch (kind) {
+    case "directory":
+      return "Folder";
+    case "file":
+      return "File";
+    case "symlink":
+      return "Shortcut";
+    default:
+      return "Other";
+  }
+}
+
+function matchesExplorerQuery(item: DirectoryItemStub, query: string) {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) {
+    return true;
+  }
+
+  return `${item.name} ${searchableKindLabel(item.kind)} ${item.path}`.toLowerCase().includes(normalizedQuery);
+}
+
+function searchableKindLabel(kind: DirectoryItemStub["kind"]) {
+  switch (kind) {
+    case "directory":
+      return "directory";
+    case "file":
+      return "file";
+    case "symlink":
+      return "symlink";
+    default:
+      return "other";
+  }
+}
+
+function normalizeExplorerPath(path: string) {
+  return path.trim().replace(/[\\/]+$/, "").toLowerCase();
+}

--- a/src/lib/stores/explorerSessionHelpers.ts
+++ b/src/lib/stores/explorerSessionHelpers.ts
@@ -92,7 +92,7 @@ export function classifyOperation(
     return "sort";
   }
 
-  if (targetPath !== state.currentPath) {
+  if (!isSameExplorerPath(targetPath, state.currentPath)) {
     return state.items.length > 0 ? "warm_navigation" : "cold_navigation";
   }
 
@@ -100,7 +100,7 @@ export function classifyOperation(
 }
 
 export function shouldPreserveVisibleRows(state: ExplorerState, targetPath: string) {
-  return state.currentPath === targetPath && state.items.length > 0;
+  return isSameExplorerPath(state.currentPath, targetPath) && state.items.length > 0;
 }
 
 export function resolveCompletedOperationType(

--- a/src/lib/stores/explorerSessionIcons.ts
+++ b/src/lib/stores/explorerSessionIcons.ts
@@ -1,0 +1,157 @@
+import { type Writable } from "svelte/store";
+import { hydrateDirectoryIcons } from "$lib/tauri/explorer";
+import {
+  applyDerivedState,
+  mergeHydratedIcons,
+  resetObsoleteLoadingIconState,
+  updateNativeIconState
+} from "$lib/stores/explorerSessionHelpers";
+import type { DirectoryItemStub, ExplorerState } from "$lib/types/explorer";
+
+type IconHydrationDeps = {
+  store: Writable<ExplorerState>;
+};
+
+export function createExplorerIconHydration({ store }: IconHydrationDeps) {
+  const queuedIconHydrationKinds = new Map<string, DirectoryItemStub["kind"]>();
+  const inflightIconHydrationGenerations = new Map<string, number>();
+  let iconHydrationTimer: ReturnType<typeof setTimeout> | null = null;
+  let iconHydrationGeneration = 0;
+
+  function hydrateVisibleIcons(items: DirectoryItemStub[]) {
+    for (const item of items) {
+      if (item.nativeIconState !== "pending") {
+        continue;
+      }
+
+      if (queuedIconHydrationKinds.has(item.path) || inflightIconHydrationGenerations.has(item.path)) {
+        continue;
+      }
+
+      queuedIconHydrationKinds.set(item.path, item.kind);
+    }
+
+    scheduleIconHydrationFlush();
+  }
+
+  function invalidateIconHydration() {
+    iconHydrationGeneration += 1;
+    clearQueuedIconHydration();
+    inflightIconHydrationGenerations.clear();
+    store.update((state) =>
+      applyDerivedState({
+        ...state,
+        items: resetObsoleteLoadingIconState(state.items),
+        pendingItems: resetObsoleteLoadingIconState(state.pendingItems)
+      })
+    );
+  }
+
+  function clearQueuedIconHydration() {
+    if (iconHydrationTimer) {
+      clearTimeout(iconHydrationTimer);
+      iconHydrationTimer = null;
+    }
+
+    queuedIconHydrationKinds.clear();
+  }
+
+  function markSnapshotCommitted() {
+    iconHydrationGeneration += 1;
+  }
+
+  function scheduleIconHydrationFlush() {
+    if (iconHydrationTimer || queuedIconHydrationKinds.size === 0) {
+      return;
+    }
+
+    iconHydrationTimer = setTimeout(() => {
+      iconHydrationTimer = null;
+      void flushIconHydrationQueue();
+    }, 0);
+  }
+
+  async function flushIconHydrationQueue() {
+    if (queuedIconHydrationKinds.size === 0) {
+      return;
+    }
+
+    const requestGeneration = iconHydrationGeneration;
+    const requestItems = [...queuedIconHydrationKinds.entries()].map(([path, kind]) => ({ path, kind }));
+    queuedIconHydrationKinds.clear();
+
+    for (const item of requestItems) {
+      inflightIconHydrationGenerations.set(item.path, requestGeneration);
+    }
+
+    markItemsLoading(requestItems.map((item) => item.path), requestGeneration);
+
+    try {
+      const response = await hydrateDirectoryIcons({ items: requestItems });
+      if (requestGeneration !== iconHydrationGeneration) {
+        return;
+      }
+
+      store.update((state) =>
+        applyDerivedState({
+          ...state,
+          items: mergeHydratedIcons(state.items, response.items),
+          pendingItems: mergeHydratedIcons(state.pendingItems, response.items)
+        })
+      );
+    } catch {
+      markItemsFailed(requestItems.map((item) => item.path), requestGeneration);
+    } finally {
+      for (const item of requestItems) {
+        if (inflightIconHydrationGenerations.get(item.path) === requestGeneration) {
+          inflightIconHydrationGenerations.delete(item.path);
+        }
+      }
+    }
+  }
+
+  function markItemsLoading(paths: string[], requestGeneration: number) {
+    if (requestGeneration !== iconHydrationGeneration) {
+      return;
+    }
+
+    if (paths.length === 0) {
+      return;
+    }
+
+    const pathSet = new Set(paths);
+    store.update((state) =>
+      applyDerivedState({
+        ...state,
+        items: updateNativeIconState(state.items, pathSet, "loading"),
+        pendingItems: updateNativeIconState(state.pendingItems, pathSet, "loading")
+      })
+    );
+  }
+
+  function markItemsFailed(paths: string[], requestGeneration: number) {
+    if (requestGeneration !== iconHydrationGeneration) {
+      return;
+    }
+
+    if (paths.length === 0) {
+      return;
+    }
+
+    const pathSet = new Set(paths);
+    store.update((state) =>
+      applyDerivedState({
+        ...state,
+        items: updateNativeIconState(state.items, pathSet, "failed"),
+        pendingItems: updateNativeIconState(state.pendingItems, pathSet, "failed")
+      })
+    );
+  }
+
+  return {
+    hydrateVisibleIcons,
+    invalidateIconHydration,
+    markSnapshotCommitted,
+    clearQueuedIconHydration
+  };
+}

--- a/src/lib/stores/explorerSessionMutations.ts
+++ b/src/lib/stores/explorerSessionMutations.ts
@@ -1,0 +1,333 @@
+import { get, type Writable } from "svelte/store";
+import { createDirectory, deleteToRecycleBin, renameDirectoryItem } from "$lib/tauri/explorer";
+import { notify } from "$lib/stores/notifications";
+import {
+  applyDerivedState,
+  clearTransientRenameFallback,
+  createMutationRestoreState,
+  createRenameRestoreState,
+  createTransientDirectoryItem,
+  formatDeleteFailureSummary,
+  formatDeleteSuccessMessage,
+  getErrorMessage,
+  getParentPath,
+  isSameExplorerPath,
+  type ExplorerRestoreState
+} from "$lib/stores/explorerSessionHelpers";
+import type {
+  DeleteToRecycleBinResponse,
+  DirectoryItemStub,
+  ExplorerState,
+  SortSpec
+} from "$lib/types/explorer";
+
+type NavigateOptions = {
+  skipHistory?: boolean;
+  refreshInPlace?: boolean;
+  sort?: SortSpec;
+  query?: string;
+  forceRefresh?: boolean;
+  restoreSelection?: boolean;
+};
+
+type MutationDeps = {
+  store: Writable<ExplorerState>;
+  navigate: (path: string, options?: NavigateOptions) => Promise<void>;
+  setPendingRestore: (restore: ExplorerRestoreState | null) => void;
+};
+
+export function createExplorerMutationActions({ store, navigate, setPendingRestore }: MutationDeps) {
+  async function createNewFolder() {
+    dismissRenameForContextChange();
+
+    const state = get(store);
+    const parentPath = state.currentPath.trim();
+    if (!parentPath) {
+      notify.error("Open a folder before creating a new folder.");
+      return false;
+    }
+
+    if (state.activeJobId) {
+      return false;
+    }
+
+    try {
+      const created = await createDirectory({ parentPath });
+      setPendingRestore(createMutationRestoreState(state, [created.path], created.path, createTransientDirectoryItem(created)));
+
+      await navigate(parentPath, {
+        skipHistory: true,
+        refreshInPlace: true,
+        forceRefresh: true,
+        restoreSelection: true
+      });
+
+      return true;
+    } catch (error) {
+      notify.error(getErrorMessage(error));
+      return false;
+    }
+  }
+
+  async function deleteItems(items: DirectoryItemStub[]) {
+    dismissRenameForContextChange();
+
+    if (items.length === 0) {
+      return false;
+    }
+
+    const selectedPaths = items.map((item) => item.path);
+
+    try {
+      const result = await deleteToRecycleBin({ targetPaths: selectedPaths });
+      applyDeleteResultState(result);
+      await refreshAfterMutation(result.affectedParentPaths);
+      notifyDeleteResult(result);
+      return result.deleted.length > 0;
+    } catch (error) {
+      notify.error(getErrorMessage(error));
+      return false;
+    }
+  }
+
+  function cancelRenameIfEditing() {
+    const renameState = get(store).rename;
+    if (!renameState || renameState.status !== "editing") {
+      return false;
+    }
+
+    store.update((state) => clearTransientRenameFallback(state));
+    return true;
+  }
+
+  function dismissRenameForContextChange() {
+    const renameState = get(store).rename;
+    if (!renameState) {
+      return false;
+    }
+
+    if (renameState.status === "editing") {
+      return cancelRenameIfEditing();
+    }
+
+    store.update((state) => clearTransientRenameFallback(state));
+    return true;
+  }
+
+  function beginRenameSelection() {
+    const state = get(store);
+    if (state.activeJobId || state.selectedIds.length !== 1) {
+      return;
+    }
+
+    const item = state.filteredItems.find((candidate) => candidate.id === state.selectedIds[0]);
+    if (!item) {
+      return;
+    }
+
+    const parentPath = getParentPath(item.path);
+    if (!parentPath) {
+      notify.error(`"${item.name}" cannot be renamed from this location.`);
+      return;
+    }
+
+    store.update((current) => ({
+      ...current,
+      rename: {
+        itemId: item.id,
+        sourcePath: item.path,
+        sourceName: item.name,
+        parentPath,
+        draftName: item.name,
+        status: "editing",
+        error: null
+      }
+    }));
+  }
+
+  function updateRenameDraft(draftName: string) {
+    store.update((state) => {
+      if (!state.rename || state.rename.status !== "editing") {
+        return state;
+      }
+
+      return {
+        ...state,
+        rename: {
+          ...state.rename,
+          draftName,
+          error: null
+        }
+      };
+    });
+  }
+
+  function cancelRename(options: { force?: boolean } = {}) {
+    const state = get(store);
+    if (!state.rename) {
+      return false;
+    }
+
+    if (state.rename.status === "submitting" && !options.force) {
+      return false;
+    }
+
+    store.update((current) => clearTransientRenameFallback(current));
+    return true;
+  }
+
+  async function submitRename() {
+    const renameState = get(store).rename;
+    if (!renameState || renameState.status !== "editing") {
+      return false;
+    }
+
+    const targetName = renameState.draftName.trim();
+    if (!targetName) {
+      store.update((state) => {
+        if (!state.rename || state.rename.itemId !== renameState.itemId) {
+          return state;
+        }
+
+        return {
+          ...state,
+          rename: {
+            ...state.rename,
+            error: "Enter a name before renaming this item."
+          }
+        };
+      });
+      notify.error("Enter a name before renaming this item.");
+      return false;
+    }
+
+    if (targetName === renameState.sourceName) {
+      cancelRename();
+      return true;
+    }
+
+    store.update((state) => {
+      if (!state.rename || state.rename.itemId !== renameState.itemId) {
+        return state;
+      }
+
+      return {
+        ...state,
+        rename: {
+          ...state.rename,
+          draftName: targetName,
+          status: "submitting",
+          error: null
+        }
+      };
+    });
+
+    try {
+      const result = await renameDirectoryItem({
+        sourcePath: renameState.sourcePath,
+        targetName
+      });
+      const state = get(store);
+      const shouldRefreshCurrentFolder = state.currentPath === renameState.parentPath;
+      const restoreState = shouldRefreshCurrentFolder
+        ? createRenameRestoreState(state, renameState.sourcePath, result.path)
+        : null;
+
+      store.update((current) => ({
+        ...current,
+        rename: null
+      }));
+
+      if (shouldRefreshCurrentFolder && restoreState) {
+        setPendingRestore(restoreState);
+        await navigate(renameState.parentPath, {
+          skipHistory: true,
+          refreshInPlace: true,
+          forceRefresh: true,
+          restoreSelection: true
+        });
+      }
+
+      notify.success(`Renamed "${renameState.sourceName}" to "${result.name}"`);
+      return true;
+    } catch (error) {
+      const message = getErrorMessage(error);
+      store.update((state) => {
+        if (!state.rename || state.rename.itemId !== renameState.itemId) {
+          return state;
+        }
+
+        return {
+          ...state,
+          rename: {
+            ...state.rename,
+            status: "editing",
+            error: message
+          }
+        };
+      });
+      notify.error(message);
+      return false;
+    }
+  }
+
+  async function refreshAfterMutation(affectedParentPaths: string[]) {
+    const { currentPath } = get(store);
+    if (!currentPath || !affectedParentPaths.some((path) => isSameExplorerPath(path, currentPath))) {
+      store.update((state) => applyDerivedState({
+        ...state,
+        selectedIds: [],
+        focusedItemId: null,
+        anchorItemId: null
+      }));
+      return;
+    }
+
+    await navigate(currentPath, {
+      skipHistory: true,
+      refreshInPlace: true,
+      forceRefresh: true,
+      restoreSelection: true
+    });
+  }
+
+  function applyDeleteResultState(result: DeleteToRecycleBinResponse) {
+    const deletedIdSet = new Set(result.deleted.map((item) => item.path));
+    if (deletedIdSet.size === 0) {
+      return;
+    }
+
+    store.update((state) => applyDerivedState({
+      ...state,
+      selectedIds: state.selectedIds.filter((itemId) => !deletedIdSet.has(itemId)),
+      focusedItemId: deletedIdSet.has(state.focusedItemId ?? "") ? null : state.focusedItemId,
+      anchorItemId: deletedIdSet.has(state.anchorItemId ?? "") ? null : state.anchorItemId
+    }));
+  }
+
+  function notifyDeleteResult(result: DeleteToRecycleBinResponse) {
+    if (result.deleted.length > 0 && result.failed.length === 0) {
+      notify.success(formatDeleteSuccessMessage(result.deleted.length));
+      return;
+    }
+
+    if (result.deleted.length > 0) {
+      notify.warning(
+        `${formatDeleteSuccessMessage(result.deleted.length)} ${formatDeleteFailureSummary(result.failed)}`
+      );
+      return;
+    }
+
+    notify.error(formatDeleteFailureSummary(result.failed));
+  }
+
+  return {
+    createNewFolder,
+    deleteItems,
+    dismissRenameForContextChange,
+    beginRenameSelection,
+    updateRenameDraft,
+    submitRename,
+    cancelRename
+  };
+}

--- a/src/lib/stores/explorerSessionSelection.ts
+++ b/src/lib/stores/explorerSessionSelection.ts
@@ -1,0 +1,191 @@
+import { get, type Writable } from "svelte/store";
+import type { DirectoryItemStub, ExplorerState } from "$lib/types/explorer";
+
+type SelectionDeps = {
+  store: Writable<ExplorerState>;
+  dismissRenameForContextChange: () => boolean;
+  openItem: (item: DirectoryItemStub) => Promise<void>;
+  cancelCurrentJob: (jobId: string) => Promise<void>;
+};
+
+export function createExplorerSelectionActions({
+  store,
+  dismissRenameForContextChange,
+  openItem,
+  cancelCurrentJob
+}: SelectionDeps) {
+  function selectSingle(itemId: string) {
+    dismissRenameForContextChange();
+
+    store.update((state) => ({
+      ...state,
+      selectedIds: [itemId],
+      focusedItemId: itemId,
+      anchorItemId: itemId
+    }));
+  }
+
+  function toggleSelection(itemId: string) {
+    dismissRenameForContextChange();
+
+    store.update((state) => {
+      const nextSelectedIds = state.selectedIds.includes(itemId)
+        ? state.selectedIds.filter((id) => id !== itemId)
+        : [...state.selectedIds, itemId];
+
+      return {
+        ...state,
+        selectedIds: nextSelectedIds,
+        focusedItemId: itemId,
+        anchorItemId: itemId
+      };
+    });
+  }
+
+  function rangeSelectTo(itemId: string) {
+    dismissRenameForContextChange();
+
+    store.update((state) => {
+      const anchorItemId = state.anchorItemId ?? state.focusedItemId;
+      if (!anchorItemId) {
+        return {
+          ...state,
+          selectedIds: [itemId],
+          focusedItemId: itemId,
+          anchorItemId: itemId
+        };
+      }
+
+      const anchorIndex = state.filteredItems.findIndex((item) => item.id === anchorItemId);
+      const targetIndex = state.filteredItems.findIndex((item) => item.id === itemId);
+
+      if (anchorIndex === -1 || targetIndex === -1) {
+        return {
+          ...state,
+          selectedIds: [itemId],
+          focusedItemId: itemId,
+          anchorItemId: itemId
+        };
+      }
+
+      const start = Math.min(anchorIndex, targetIndex);
+      const end = Math.max(anchorIndex, targetIndex);
+
+      return {
+        ...state,
+        selectedIds: state.filteredItems.slice(start, end + 1).map((item) => item.id),
+        focusedItemId: itemId,
+        anchorItemId
+      };
+    });
+  }
+
+  function selectWithModifiers(
+    itemId: string,
+    options: { shiftKey: boolean; ctrlKey: boolean; metaKey: boolean }
+  ) {
+    if (options.shiftKey) {
+      rangeSelectTo(itemId);
+      return;
+    }
+
+    if (options.ctrlKey || options.metaKey) {
+      toggleSelection(itemId);
+      return;
+    }
+
+    selectSingle(itemId);
+  }
+
+  function selectAllVisible() {
+    dismissRenameForContextChange();
+
+    store.update((state) => ({
+      ...state,
+      selectedIds: state.filteredItems.map((item) => item.id),
+      focusedItemId: state.focusedItemId ?? state.filteredItems[0]?.id ?? null,
+      anchorItemId: state.anchorItemId ?? state.filteredItems[0]?.id ?? null
+    }));
+  }
+
+  function clearSelection() {
+    dismissRenameForContextChange();
+
+    store.update((state) => ({
+      ...state,
+      selectedIds: [],
+      focusedItemId: null,
+      anchorItemId: null
+    }));
+  }
+
+  function moveFocus(delta: number) {
+    dismissRenameForContextChange();
+
+    const state = get(store);
+    if (state.filteredItems.length === 0) {
+      return;
+    }
+
+    const currentIndex = state.filteredItems.findIndex((item) => item.id === state.focusedItemId);
+    const nextIndex = currentIndex === -1
+      ? delta < 0
+        ? state.filteredItems.length - 1
+        : 0
+      : Math.max(0, Math.min(state.filteredItems.length - 1, currentIndex + delta));
+    const target = state.filteredItems[nextIndex];
+
+    if (target) {
+      selectSingle(target.id);
+    }
+  }
+
+  function focusFirst() {
+    dismissRenameForContextChange();
+
+    const first = get(store).filteredItems[0];
+    if (first) {
+      selectSingle(first.id);
+    }
+  }
+
+  function focusLast() {
+    dismissRenameForContextChange();
+
+    const last = get(store).filteredItems.at(-1);
+    if (last) {
+      selectSingle(last.id);
+    }
+  }
+
+  async function openFocused() {
+    const state = get(store);
+    const target = state.filteredItems.find((item) => item.id === state.focusedItemId)
+      ?? state.filteredItems.find((item) => item.id === state.selectedIds[0]);
+
+    if (target) {
+      await openItem(target);
+    }
+  }
+
+  async function cancelActiveNavigation() {
+    const activeJobId = get(store).activeJobId;
+    if (activeJobId) {
+      await cancelCurrentJob(activeJobId);
+    }
+  }
+
+  return {
+    selectSingle,
+    toggleSelection,
+    rangeSelectTo,
+    selectWithModifiers,
+    selectAllVisible,
+    clearSelection,
+    moveFocus,
+    focusFirst,
+    focusLast,
+    openFocused,
+    cancelActiveNavigation
+  };
+}

--- a/src/lib/stores/explorerWorkspace.ts
+++ b/src/lib/stores/explorerWorkspace.ts
@@ -3,6 +3,8 @@ import { getCurrentWebviewWindow, WebviewWindow } from "@tauri-apps/api/webviewW
 import { get, writable } from "svelte/store";
 import { createExplorerSession, type ExplorerSession } from "$lib/stores/explorerSessionCore";
 import { createExplorerUiStore, type ExplorerUiStore } from "$lib/stores/explorerUiCore";
+import { createWorkspaceSessionPersistence, readSession, type SessionSnapshot } from "$lib/stores/explorerWorkspaceSession";
+import { settings } from "$lib/stores/settings";
 import type {
   ExplorerTabDetachResult,
   ExplorerTabId,
@@ -76,6 +78,15 @@ function createExplorerWorkspace() {
   let detachResultUnlisten: (() => void) | null = null;
   let importTabUnlisten: (() => void) | null = null;
   let registryIntervalId: number | null = null;
+  let settingsUnsubscribe: (() => void) | null = null;
+  const sessionPersistence = createWorkspaceSessionPersistence({
+    readActiveTabId: () => get(store).activeTabId,
+    readTabOrder: () => [...tabs.keys()],
+    readTabs: () => [...tabs.values()].map((tabRecord) => ({
+      ...tabRecord.session.createSnapshot(),
+      customTitle: tabRecord.customTitle
+    }))
+  });
 
   function subscribe(run: Parameters<typeof store.subscribe>[0]) {
     return store.subscribe(run);
@@ -86,11 +97,39 @@ function createExplorerWorkspace() {
     store.set(createInitialWorkspaceState(windowId));
     await ensureEventListeners();
     startWindowRegistry();
+    const canPersistSession = !options.bootstrap?.tab;
+    settingsUnsubscribe?.();
+
+    settingsUnsubscribe = settings.subscribe((currentSettings) => {
+      if (!currentSettings.sessionRestoreEnabled) {
+        sessionPersistence.disable();
+      } else if (canPersistSession) {
+        sessionPersistence.enable();
+      }
+    });
+
+    if (canPersistSession && get(settings).sessionRestoreEnabled) {
+      sessionPersistence.enable();
+    } else {
+      sessionPersistence.pause();
+    }
 
     if (options.bootstrap?.tab) {
       await createTab({ snapshot: options.bootstrap.tab, makeActive: true });
     } else {
-      await createTab({ makeActive: true });
+      if (get(settings).sessionRestoreEnabled) {
+        const sessionSnapshot = readSession();
+        if (sessionSnapshot && sessionSnapshot.tabOrder.length > 0) {
+          await restoreSession(sessionSnapshot);
+          if (tabs.size === 0) {
+            await createTab({ makeActive: true });
+          }
+        } else {
+          await createTab({ makeActive: true });
+        }
+      } else {
+        await createTab({ makeActive: true });
+      }
     }
 
     store.update((state) => ({ ...state, initialized: true }));
@@ -121,6 +160,7 @@ function createExplorerWorkspace() {
       record.title = record.customTitle ?? record.derivedTitle;
       record.iconDataUrl = findMatchingSidebarRoot(state.currentPath, state.roots)?.iconDataUrl;
       syncState();
+      sessionPersistence.markDirty();
     });
 
     tabs.set(tabId, record);
@@ -128,6 +168,22 @@ function createExplorerWorkspace() {
     await session.initialize(snapshot ? { path: snapshot.currentPath, snapshot } : {});
     syncState(get(store).activeTabId ?? tabId);
     return tabId;
+  }
+
+  async function restoreSession(sessionSnapshot: SessionSnapshot) {
+    const snapshotsById = new Map(sessionSnapshot.tabs.map((snapshot) => [snapshot.tabId, snapshot]));
+    const orderedSnapshots = sessionSnapshot.tabOrder
+      .map((tabId) => snapshotsById.get(tabId))
+      .filter((snapshot): snapshot is ExplorerTabSnapshot => snapshot !== undefined);
+
+    for (const tabSnapshot of orderedSnapshots) {
+      await createTab({ snapshot: tabSnapshot, preserveTabId: true });
+    }
+
+    const restoredActiveTabId = sessionSnapshot.activeTabId;
+    if (restoredActiveTabId && tabs.has(restoredActiveTabId)) {
+      syncState(restoredActiveTabId);
+    }
   }
 
   async function newTab() {
@@ -143,6 +199,7 @@ function createExplorerWorkspace() {
     record.customTitle = normalizeCustomTabTitle(title);
     record.title = record.customTitle ?? record.derivedTitle;
     syncState();
+    sessionPersistence.markDirty();
   }
 
   function clearTabTitle(tabId: ExplorerTabId) {
@@ -154,6 +211,7 @@ function createExplorerWorkspace() {
     record.customTitle = null;
     record.title = record.derivedTitle;
     syncState();
+    sessionPersistence.markDirty();
   }
 
   function moveTabBefore(tabId: ExplorerTabId, targetTabId: ExplorerTabId | null) {
@@ -198,6 +256,7 @@ function createExplorerWorkspace() {
     }
 
     syncState(tabId);
+    sessionPersistence.markDirty();
   }
 
   async function closeTab(tabId: ExplorerTabId) {
@@ -210,12 +269,14 @@ function createExplorerWorkspace() {
     if (tabs.size === 1) {
       disposeTab(tabId);
       await createTab({ makeActive: true });
+      sessionPersistence.markDirty();
       return;
     }
 
     if (activeTabId && activeTabId !== tabId) {
       disposeTab(tabId);
       syncState(activeTabId);
+      sessionPersistence.markDirty();
       return;
     }
 
@@ -224,6 +285,7 @@ function createExplorerWorkspace() {
     disposeTab(tabId);
     const nextTabId = tabIds[currentIndex + 1] ?? tabIds[currentIndex - 1] ?? [...tabs.keys()][0] ?? null;
     syncState(nextTabId);
+    sessionPersistence.markDirty();
   }
 
   async function detachTab(tabId: ExplorerTabId, screenPosition?: { x: number; y: number }) {
@@ -357,11 +419,15 @@ function createExplorerWorkspace() {
   }
 
   function dispose() {
+    sessionPersistence.saveNow();
     disposeTabs();
+    sessionPersistence.pause();
     detachResultUnlisten?.();
     importTabUnlisten?.();
     detachResultUnlisten = null;
     importTabUnlisten = null;
+    settingsUnsubscribe?.();
+    settingsUnsubscribe = null;
     stopWindowRegistry();
     store.set(createInitialWorkspaceState(windowId));
   }
@@ -444,6 +510,7 @@ function createExplorerWorkspace() {
     }
 
     syncState(get(store).activeTabId);
+    sessionPersistence.markDirty();
   }
 
   function startWindowRegistry() {

--- a/src/lib/stores/explorerWorkspace.ts
+++ b/src/lib/stores/explorerWorkspace.ts
@@ -99,20 +99,7 @@ function createExplorerWorkspace() {
     startWindowRegistry();
     const canPersistSession = !options.bootstrap?.tab;
     settingsUnsubscribe?.();
-
-    settingsUnsubscribe = settings.subscribe((currentSettings) => {
-      if (!currentSettings.sessionRestoreEnabled) {
-        sessionPersistence.disable();
-      } else if (canPersistSession) {
-        sessionPersistence.enable();
-      }
-    });
-
-    if (canPersistSession && get(settings).sessionRestoreEnabled) {
-      sessionPersistence.enable();
-    } else {
-      sessionPersistence.pause();
-    }
+    sessionPersistence.pause();
 
     if (options.bootstrap?.tab) {
       await createTab({ snapshot: options.bootstrap.tab, makeActive: true });
@@ -133,6 +120,14 @@ function createExplorerWorkspace() {
     }
 
     store.update((state) => ({ ...state, initialized: true }));
+
+    settingsUnsubscribe = settings.subscribe((currentSettings) => {
+      if (!currentSettings.sessionRestoreEnabled) {
+        sessionPersistence.disable();
+      } else if (canPersistSession) {
+        sessionPersistence.enable();
+      }
+    });
   }
 
   async function createTab(options: { snapshot?: ExplorerTabSnapshot; makeActive?: boolean; preserveTabId?: boolean } = {}) {

--- a/src/lib/stores/explorerWorkspaceSession.ts
+++ b/src/lib/stores/explorerWorkspaceSession.ts
@@ -1,0 +1,178 @@
+import type { ExplorerTabId, ExplorerTabSnapshot } from "$lib/types/explorer";
+
+const SESSION_STORAGE_KEY = "file-explorer.session.v1";
+const SESSION_STALENESS_THRESHOLD_MS = 7 * 24 * 60 * 60 * 1000;
+
+export type SessionSnapshot = {
+  version: 1;
+  savedAt: number;
+  activeTabId: ExplorerTabId | null;
+  tabOrder: ExplorerTabId[];
+  tabs: ExplorerTabSnapshot[];
+};
+
+type WorkspaceSessionPersistenceDeps = {
+  readActiveTabId: () => ExplorerTabId | null;
+  readTabOrder: () => ExplorerTabId[];
+  readTabs: () => ExplorerTabSnapshot[];
+};
+
+export function createWorkspaceSessionPersistence({
+  readActiveTabId,
+  readTabOrder,
+  readTabs
+}: WorkspaceSessionPersistenceDeps) {
+  let saveDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+  let beforeUnloadUnlisten: (() => void) | null = null;
+  let pageHideUnlisten: (() => void) | null = null;
+  let isSessionDirty = false;
+  let shouldPersistSession = false;
+
+  function enable() {
+    shouldPersistSession = true;
+    startAutoSave();
+  }
+
+  function pause() {
+    stopAutoSave();
+    shouldPersistSession = false;
+  }
+
+  function disable() {
+    window.localStorage.removeItem(SESSION_STORAGE_KEY);
+    pause();
+  }
+
+  function markDirty() {
+    if (!shouldPersistSession) {
+      return;
+    }
+
+    isSessionDirty = true;
+    scheduleAutoSave();
+  }
+
+  function saveNow() {
+    if (!shouldPersistSession) {
+      return;
+    }
+
+    const payload: SessionSnapshot = {
+      version: 1,
+      savedAt: Date.now(),
+      activeTabId: readActiveTabId(),
+      tabOrder: readTabOrder(),
+      tabs: readTabs()
+    };
+
+    try {
+      window.localStorage.setItem(SESSION_STORAGE_KEY, JSON.stringify(payload));
+    } catch {
+      // Storage can be unavailable or full; session restore should never break explorer runtime.
+    }
+  }
+
+  function dispose() {
+    saveNow();
+    pause();
+  }
+
+  function scheduleAutoSave() {
+    if (!shouldPersistSession) {
+      return;
+    }
+
+    if (saveDebounceTimer !== null) {
+      return;
+    }
+
+    saveDebounceTimer = window.setTimeout(() => {
+      saveDebounceTimer = null;
+      if (isSessionDirty) {
+        saveNow();
+        isSessionDirty = false;
+      }
+    }, 200);
+  }
+
+  function startAutoSave() {
+    if (beforeUnloadUnlisten !== null) {
+      return;
+    }
+
+    beforeUnloadUnlisten = () => {
+      if (saveDebounceTimer !== null) {
+        window.clearTimeout(saveDebounceTimer);
+        saveDebounceTimer = null;
+      }
+      saveNow();
+    };
+
+    pageHideUnlisten = () => {
+      saveNow();
+    };
+
+    window.addEventListener("beforeunload", beforeUnloadUnlisten);
+    window.addEventListener("pagehide", pageHideUnlisten);
+  }
+
+  function stopAutoSave() {
+    if (saveDebounceTimer !== null) {
+      window.clearTimeout(saveDebounceTimer);
+      saveDebounceTimer = null;
+    }
+
+    if (beforeUnloadUnlisten !== null) {
+      window.removeEventListener("beforeunload", beforeUnloadUnlisten);
+      beforeUnloadUnlisten = null;
+    }
+
+    if (pageHideUnlisten !== null) {
+      window.removeEventListener("pagehide", pageHideUnlisten);
+      pageHideUnlisten = null;
+    }
+  }
+
+  return {
+    enable,
+    pause,
+    disable,
+    markDirty,
+    saveNow,
+    dispose
+  };
+}
+
+export function readSession(): SessionSnapshot | null {
+  try {
+    const raw = window.localStorage.getItem(SESSION_STORAGE_KEY);
+    if (!raw) {
+      return null;
+    }
+
+    const parsed = JSON.parse(raw) as SessionSnapshot;
+    if (parsed.version !== 1) {
+      return null;
+    }
+
+    if (!Number.isFinite(parsed.savedAt)) {
+      return null;
+    }
+
+    if (Date.now() - parsed.savedAt > SESSION_STALENESS_THRESHOLD_MS) {
+      return null;
+    }
+
+    if (!parsed.tabOrder || !Array.isArray(parsed.tabOrder)) {
+      return null;
+    }
+
+    if (!parsed.tabs || !Array.isArray(parsed.tabs)) {
+      return null;
+    }
+
+    return parsed;
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/stores/explorerWorkspaceSession.ts
+++ b/src/lib/stores/explorerWorkspaceSession.ts
@@ -150,7 +150,11 @@ export function readSession(): SessionSnapshot | null {
       return null;
     }
 
-    const parsed = JSON.parse(raw) as SessionSnapshot;
+    const parsed = JSON.parse(raw) as unknown;
+    if (!isSessionSnapshotCandidate(parsed)) {
+      return null;
+    }
+
     if (parsed.version !== 1) {
       return null;
     }
@@ -163,16 +167,86 @@ export function readSession(): SessionSnapshot | null {
       return null;
     }
 
-    if (!parsed.tabOrder || !Array.isArray(parsed.tabOrder)) {
+    const tabIds = new Set(parsed.tabOrder);
+    if (tabIds.size !== parsed.tabOrder.length) {
       return null;
     }
 
-    if (!parsed.tabs || !Array.isArray(parsed.tabs)) {
+    if (parsed.activeTabId !== null && !tabIds.has(parsed.activeTabId)) {
       return null;
     }
 
-    return parsed;
+    const snapshotIds = new Set(parsed.tabs.map((tab) => tab.tabId));
+    if (snapshotIds.size !== parsed.tabs.length || snapshotIds.size !== tabIds.size) {
+      return null;
+    }
+
+    if (parsed.tabs.some((tab) => !tabIds.has(tab.tabId))) {
+      return null;
+    }
+
+    return parsed satisfies SessionSnapshot;
   } catch {
     return null;
   }
+}
+
+function isSessionSnapshotCandidate(value: unknown): value is SessionSnapshot {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const candidate = value as Record<string, unknown>;
+  return candidate.version === 1
+    && Number.isFinite(candidate.savedAt)
+    && isTabIdOrNull(candidate.activeTabId)
+    && Array.isArray(candidate.tabOrder)
+    && candidate.tabOrder.every(isTabId)
+    && Array.isArray(candidate.tabs)
+    && candidate.tabs.every(isExplorerTabSnapshot);
+}
+
+function isExplorerTabSnapshot(value: unknown): value is ExplorerTabSnapshot {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const candidate = value as Record<string, unknown>;
+  return isTabId(candidate.tabId)
+    && typeof candidate.currentPath === "string"
+    && (candidate.customTitle === null || typeof candidate.customTitle === "string")
+    && isSortSpec(candidate.sort)
+    && typeof candidate.stagedSearchQuery === "string"
+    && typeof candidate.appliedSearchQuery === "string"
+    && isStringArray(candidate.selectedIds)
+    && isStringOrNull(candidate.focusedItemId)
+    && isStringOrNull(candidate.anchorItemId)
+    && isStringArray(candidate.backHistory)
+    && isStringArray(candidate.forwardHistory);
+}
+
+function isSortSpec(value: unknown) {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const candidate = value as Record<string, unknown>;
+  return ["name", "type", "modifiedAt", "size"].includes(String(candidate.field))
+    && ["asc", "desc"].includes(String(candidate.direction));
+}
+
+function isTabId(value: unknown): value is ExplorerTabId {
+  return typeof value === "string" && value.length > 0;
+}
+
+function isTabIdOrNull(value: unknown): value is ExplorerTabId | null {
+  return value === null || isTabId(value);
+}
+
+function isStringOrNull(value: unknown): value is string | null {
+  return value === null || typeof value === "string";
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === "string");
 }

--- a/src/lib/stores/settings.ts
+++ b/src/lib/stores/settings.ts
@@ -5,6 +5,7 @@ export type ThemePreference = "system" | "light" | "dark";
 export type SettingsState = {
   themePreference: ThemePreference;
   artificialNavDelayMs: number;
+  sessionRestoreEnabled: boolean;
 };
 
 const STORAGE_KEY = "file-explorer.settings.v1";
@@ -12,7 +13,8 @@ const DEFAULT_DELAY = parseDelay(import.meta.env.VITE_EXPLORER_NAV_DELAY_MS);
 
 const defaults: SettingsState = {
   themePreference: "system",
-  artificialNavDelayMs: DEFAULT_DELAY
+  artificialNavDelayMs: DEFAULT_DELAY,
+  sessionRestoreEnabled: true
 };
 
 function createSettingsStore() {
@@ -38,6 +40,9 @@ function createSettingsStore() {
         artificialNavDelayMs: clampDelay(artificialNavDelayMs)
       }));
     },
+    setSessionRestoreEnabled(sessionRestoreEnabled: boolean) {
+      store.update((state) => ({ ...state, sessionRestoreEnabled }));
+    },
     reset() {
       store.set(defaults);
     }
@@ -59,7 +64,8 @@ function loadInitialState(): SettingsState {
     const parsed = JSON.parse(raw) as Partial<SettingsState>;
     const state: SettingsState = {
       themePreference: isThemePreference(parsed.themePreference) ? parsed.themePreference : defaults.themePreference,
-      artificialNavDelayMs: clampDelay(parsed.artificialNavDelayMs ?? defaults.artificialNavDelayMs)
+      artificialNavDelayMs: clampDelay(parsed.artificialNavDelayMs ?? defaults.artificialNavDelayMs),
+      sessionRestoreEnabled: typeof parsed.sessionRestoreEnabled === "boolean" ? parsed.sessionRestoreEnabled : defaults.sessionRestoreEnabled
     };
 
     applyThemePreference(state.themePreference);

--- a/src/lib/stores/settingsUi.ts
+++ b/src/lib/stores/settingsUi.ts
@@ -1,6 +1,6 @@
 import { writable } from "svelte/store";
 
-export type SettingsSection = "appearance" | "developer" | "about";
+export type SettingsSection = "general" | "appearance" | "developer" | "about";
 
 type SettingsUiState = {
   open: boolean;
@@ -9,7 +9,7 @@ type SettingsUiState = {
 
 const initialState: SettingsUiState = {
   open: false,
-  section: "appearance"
+  section: "general"
 };
 
 function createSettingsUiStore() {
@@ -17,7 +17,7 @@ function createSettingsUiStore() {
 
   return {
     subscribe: store.subscribe,
-    openSettings(section: SettingsSection = "appearance") {
+    openSettings(section: SettingsSection = "general") {
       store.set({ open: true, section });
     },
     closeSettings() {


### PR DESCRIPTION
## Summary
- Move portable directory projection into the core crate with tests.
- Split oversized explorer session and workspace stores into focused modules.
- Route Bun scripts through direct CLI entrypoints so Windows checks run reliably.

## Testing
- cargo test
- cargo check
- bun run check
- bun run build
- bun run tauri --version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added session restore functionality to persist and recover open tabs, active tab selection, and custom titles across sessions.
  * Introduced "Restore previous session" toggle in General settings to control session persistence behavior.
  * Enhanced directory search and filtering with improved sorting capabilities.

* **Chores**
  * Updated build scripts to invoke development tools via `bun` instead of individual commands.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Timpan4/file-explorer/pull/14?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->