### PR TITLE
Add PR CI verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,61 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Verify (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - windows-latest
+          - ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+        with:
+          toolchain: stable
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+        with:
+          bun-version: 1.3.14
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run typecheck
+        run: bun run typecheck
+
+      - name: Run frontend tests
+        run: bun run test
+
+      - name: Run Rust tests
+        run: bun run rust:test
+
+      - name: Run Rust check
+        run: bun run rust:check
+
+      - name: Build frontend
+        run: bun run build


### PR DESCRIPTION
## Summary
- Add GitHub Actions PR verification for the testing standard on Windows and Ubuntu.
- Run explicit typecheck, frontend test, Rust test, Rust check, and build gates in CI.
- Harden workflow setup with pinned action SHAs, pinned Bun `1.3.14`, and checkout credential persistence disabled.

## Testing
- bun run typecheck
- bun run test
- bun run rust:test
- bun run rust:check
- bun run check
- bun run build